### PR TITLE
Rehydration enchantment

### DIFF
--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -2,10 +2,7 @@ package com.github.thedeathlycow.scorchful;
 
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
-import com.github.thedeathlycow.scorchful.registry.SItemGroups;
-import com.github.thedeathlycow.scorchful.registry.SItems;
-import com.github.thedeathlycow.scorchful.registry.SSoundEvents;
-import com.github.thedeathlycow.scorchful.registry.STemperatureEffects;
+import com.github.thedeathlycow.scorchful.registry.*;
 import com.github.thedeathlycow.scorchful.server.ThirstCommand;
 import com.github.thedeathlycow.scorchful.temperature.AmbientTemperatureController;
 import com.github.thedeathlycow.scorchful.temperature.AttributeController;
@@ -45,6 +42,7 @@ public class Scorchful implements ModInitializer {
         SItemGroups.registerAll();
         SSoundEvents.registerAll();
         STemperatureEffects.registerAll();
+        SEnchantments.registerAll();
 
         CommandRegistrationCallback.EVENT.register(
                 (dispatcher, registryAccess, environment) -> {

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -14,6 +14,8 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.minecraft.entity.damage.DamageTypes;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
@@ -61,6 +63,7 @@ public class Scorchful implements ModInitializer {
                     }
                 }
         );
+
 
         this.registerThermooEventListeners();
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.scorchful;
 
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
+import com.github.thedeathlycow.scorchful.enchantment.RehydrationEnchantment;
 import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
 import com.github.thedeathlycow.scorchful.registry.*;
 import com.github.thedeathlycow.scorchful.server.ThirstCommand;
@@ -45,6 +46,7 @@ public class Scorchful implements ModInitializer {
         SSoundEvents.registerAll();
         STemperatureEffects.registerAll();
         SEnchantments.registerAll();
+        RehydrationEnchantment.addToNetherLoot();
 
         CommandRegistrationCallback.EVENT.register(
                 (dispatcher, registryAccess, environment) -> {

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -2,18 +2,23 @@ package com.github.thedeathlycow.scorchful.components;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.config.ThirstConfig;
+import com.github.thedeathlycow.scorchful.enchantment.SEnchantmentHelper;
 import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
 import dev.onyxstudios.cca.api.v3.component.Component;
 import dev.onyxstudios.cca.api.v3.component.tick.ServerTickingComponent;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 public class PlayerComponent implements Component, ServerTickingComponent {
 
-    public static final int MAX_WATER = 300;
+    public static final int MAX_WATER = 600;
 
     private static final String WATER_KEY = "body_water";
 
@@ -21,6 +26,8 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     private final PlayerEntity provider;
 
     private int water = 0;
+
+    private int capturedWater = 0;
 
     public PlayerComponent(PlayerEntity provider) {
         this.provider = provider;
@@ -62,13 +69,14 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     private void tickWater() {
         ThirstConfig config = Scorchful.getConfig().thirstConfig;
 
+        // sweating: move body water to wetness
         if (this.water > 0 && this.provider.thermoo$getTemperature() > 0) {
             this.water--;
-            this.provider.thermoo$setWetTicks(this.provider.thermoo$getWetTicks() + config.getWetnessFromBodyWater());
+            this.provider.thermoo$setWetTicks(this.provider.thermoo$getWetTicks() + 1);
         }
 
+        // cooling: move wetness to temperature
         if (this.provider.thermoo$isWet()) {
-
             int temperatureChange = config.getTemperatureFromWetness();
             World world = this.provider.getWorld();
             if (world.getBiome(this.provider.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
@@ -76,7 +84,79 @@ public class PlayerComponent implements Component, ServerTickingComponent {
             }
 
             this.provider.thermoo$addTemperature(temperatureChange);
+
+            if (temperatureChange < 0) {
+                this.tickRehydration(config);
+            }
+            //TODO: drying should maybe be moved here
         }
     }
 
+    private void tickRehydration(ThirstConfig config) {
+        int rehydrationLevel = SEnchantmentHelper.getTotalRehydrationForPlayer(this.provider);
+
+        if (rehydrationLevel == 0) {
+            this.capturedWater = 0;
+            return;
+        }
+
+        // REHYDRATION EXPLANATION
+        // The Rehydration enchantment builds up a drink whenever the player loses wetness (not body water) to cooling
+        // That drink is the same size as a hydrating drink.
+        // When the drink is full, the player is given back all the water in the drink as *body* water.
+        // However, some of that water is lost, based on the total level of Rehydration.
+
+        int rehydrationCapacity = config.getWaterFromHydratingFood();
+        this.capturedWater = Math.min(this.capturedWater + 1, rehydrationCapacity);
+
+        if (capturedWater == rehydrationCapacity && this.water <= 1) {
+            this.rehydrate(config, rehydrationLevel);
+        }
+    }
+
+    private void rehydrate(ThirstConfig config, int rehydrationLevel) {
+
+        float efficiency = getRehydrationEfficiency(
+                rehydrationLevel,
+                config.getMinRehydrationEfficiency(), config.getMaxRehydrationEfficiency()
+        );
+        int addedWater = MathHelper.floor(this.capturedWater * efficiency);
+
+        this.addWater(addedWater);
+        this.capturedWater = 0;
+
+        if (addedWater > 0 && this.provider.getWorld() instanceof ServerWorld serverWorld) {
+            this.playRehydrationEffects(serverWorld);
+        }
+    }
+
+    private void playRehydrationEffects(ServerWorld serverWorld) {
+        Vec3d pos = this.provider.getPos();
+
+        if (!this.provider.isSilent()) {
+            serverWorld.playSound(
+                    null,
+                    this.provider.getBlockPos(),
+                    SoundEvents.ITEM_BOTTLE_FILL,
+                    this.provider.getSoundCategory()
+            );
+        }
+
+        if (!this.provider.isInvisible()) {
+            float height = this.provider.getHeight();
+            float width = this.provider.getWidth();
+
+            serverWorld.spawnParticles(
+                    ParticleTypes.BUBBLE_POP,
+                    pos.x, pos.y, pos.z,
+                    50,
+                    width, height, width,
+                    1f / 1000f
+            );
+        }
+    }
+
+    private static float getRehydrationEfficiency(int rehydrationLevel, float min, float max) {
+        return MathHelper.lerp(rehydrationLevel / 4f, min, max);
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -90,14 +90,10 @@ public class PlayerComponent implements Component, ServerTickingComponent {
             }
 
             this.provider.thermoo$addTemperature(temperatureChange);
-
-            if (temperatureChange < 0) {
-                this.tickRehydration(config);
-            }
         }
     }
 
-    private void tickRehydration(ThirstConfig config) {
+    public void tickRehydration(ThirstConfig config) {
         int rehydrationLevel = SEnchantmentHelper.getTotalRehydrationForPlayer(this.provider);
 
         if (rehydrationLevel == 0) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -138,7 +138,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     private void playRehydrationEffects(ServerWorld serverWorld) {
         Vec3d pos = this.provider.getPos();
 
-        if (!this.provider.isSilent()) {
+        if (!this.provider.isSilent() && !this.provider.isSneaking()) {
             serverWorld.playSound(
                     null,
                     this.provider.getBlockPos(),

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -107,7 +107,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
         // When the drink is full, the player is given back all the water in the drink as *body* water.
         // However, some of that water is lost, based on the total level of Rehydration.
 
-        int rehydrationCapacity = config.getWaterFromHydratingFood();
+        int rehydrationCapacity = config.getRehydrationDrinkSize();
         this.rehydrationDrink = Math.min(this.rehydrationDrink + 1, rehydrationCapacity);
 
         if (rehydrationDrink == rehydrationCapacity && this.waterDrunk <= 1) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -3,6 +3,7 @@ package com.github.thedeathlycow.scorchful.components;
 import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.config.ThirstConfig;
 import com.github.thedeathlycow.scorchful.enchantment.SEnchantmentHelper;
+import com.github.thedeathlycow.scorchful.registry.SSoundEvents;
 import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
 import dev.onyxstudios.cca.api.v3.component.Component;
 import dev.onyxstudios.cca.api.v3.component.tick.ServerTickingComponent;
@@ -138,7 +139,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
             serverWorld.playSound(
                     null,
                     this.provider.getBlockPos(),
-                    SoundEvents.ITEM_BOTTLE_FILL,
+                    SSoundEvents.REHYDRATE,
                     this.provider.getSoundCategory()
             );
         }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -7,15 +7,13 @@ import me.shedaniel.autoconfig.annotation.Config;
 @Config(name = Scorchful.MODID + ".thirst_config")
 public class ThirstConfig implements ConfigData {
 
-    int wetnessFromBodyWater = 2;
-
     int temperatureFromWetness = -12;
 
-    int waterFromRefreshingFood = 15;
+    int waterFromRefreshingFood = 30;
 
-    int waterFromSustainingFood = 30;
+    int waterFromSustainingFood = 60;
 
-    int waterFromHydratingFood = 60;
+    int waterFromHydratingFood = 120;
 
     int soakingFromSplashPotions = 300;
 
@@ -29,9 +27,9 @@ public class ThirstConfig implements ConfigData {
 
     float humidBiomeSweatEfficiency = 1f / 6f;
 
-    public int getWetnessFromBodyWater() {
-        return wetnessFromBodyWater;
-    }
+    float minRehydrationEfficiency = 0f;
+
+    float maxRehydrationEfficiency = 0.75f;
 
     public int getTemperatureFromWetness() {
         return temperatureFromWetness;
@@ -71,5 +69,13 @@ public class ThirstConfig implements ConfigData {
 
     public float getHumidBiomeSweatEfficiency() {
         return humidBiomeSweatEfficiency;
+    }
+
+    public float getMinRehydrationEfficiency() {
+        return minRehydrationEfficiency;
+    }
+
+    public float getMaxRehydrationEfficiency() {
+        return maxRehydrationEfficiency;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -27,8 +27,6 @@ public class ThirstConfig implements ConfigData {
 
     float humidBiomeSweatEfficiency = 1f / 6f;
 
-    float minRehydrationEfficiency = 0f;
-
     float maxRehydrationEfficiency = 0.75f;
 
     public int getTemperatureFromWetness() {
@@ -69,10 +67,6 @@ public class ThirstConfig implements ConfigData {
 
     public float getHumidBiomeSweatEfficiency() {
         return humidBiomeSweatEfficiency;
-    }
-
-    public float getMinRehydrationEfficiency() {
-        return minRehydrationEfficiency;
     }
 
     public float getMaxRehydrationEfficiency() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -15,6 +15,8 @@ public class ThirstConfig implements ConfigData {
 
     int waterFromHydratingFood = 120;
 
+    int rehydrationDrinkSize = 120;
+
     int soakingFromSplashPotions = 300;
 
     int rainWetnessIncrease = 1;
@@ -43,6 +45,10 @@ public class ThirstConfig implements ConfigData {
 
     public int getWaterFromHydratingFood() {
         return waterFromHydratingFood;
+    }
+
+    public int getRehydrationDrinkSize() {
+        return rehydrationDrinkSize;
     }
 
     public int getSoakingFromSplashPotions() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
@@ -1,13 +1,11 @@
 package com.github.thedeathlycow.scorchful.enchantment;
 
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 
 public class RehydrationEnchantment extends Enchantment {
+
     public RehydrationEnchantment(Rarity weight, EquipmentSlot[] slotTypes) {
         super(weight, EnchantmentTarget.ARMOR, slotTypes);
     }
@@ -22,8 +20,4 @@ public class RehydrationEnchantment extends Enchantment {
         return this.getMinPower(level) + 40;
     }
 
-    @Override
-    public int getMaxLevel() {
-        return 3;
-    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
@@ -1,0 +1,29 @@
+package com.github.thedeathlycow.scorchful.enchantment;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.EnchantmentTarget;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+public class RehydrationEnchantment extends Enchantment {
+    public RehydrationEnchantment(Rarity weight, EquipmentSlot[] slotTypes) {
+        super(weight, EnchantmentTarget.ARMOR, slotTypes);
+    }
+
+    @Override
+    public int getMinPower(int level) {
+        return 1;
+    }
+
+    @Override
+    public int getMaxPower(int level) {
+        return this.getMinPower(level) + 40;
+    }
+
+    @Override
+    public int getMaxLevel() {
+        return 3;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/enchantment/RehydrationEnchantment.java
@@ -1,8 +1,19 @@
 package com.github.thedeathlycow.scorchful.enchantment;
 
+import com.github.thedeathlycow.scorchful.registry.SEnchantments;
+import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
+import net.fabricmc.fabric.api.loot.v2.LootTableSource;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.item.Items;
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.condition.RandomChanceLootCondition;
+import net.minecraft.loot.entry.EmptyEntry;
+import net.minecraft.loot.entry.ItemEntry;
+import net.minecraft.loot.function.EnchantRandomlyLootFunction;
+import net.minecraft.loot.provider.number.ConstantLootNumberProvider;
+import net.minecraft.util.Identifier;
 
 public class RehydrationEnchantment extends Enchantment {
 
@@ -12,12 +23,77 @@ public class RehydrationEnchantment extends Enchantment {
 
     @Override
     public int getMinPower(int level) {
-        return 1;
+        return level * 25;
     }
 
     @Override
     public int getMaxPower(int level) {
-        return this.getMinPower(level) + 40;
+        return this.getMinPower(level) + 50;
     }
 
+    @Override
+    public boolean isTreasure() {
+        return true;
+    }
+
+    @Override
+    public boolean isAvailableForEnchantedBookOffer() {
+        return false;
+    }
+
+    @Override
+    public boolean isAvailableForRandomSelection() {
+        return false;
+    }
+
+    public static void addToNetherLoot() {
+        var piglinBarterLoot = new Identifier("gameplay/piglin_bartering");
+        LootTableEvents.MODIFY.register(
+                (resourceManager, lootManager, id, tableBuilder, source) -> {
+                    if (source != LootTableSource.DATA_PACK && id.equals(piglinBarterLoot)) {
+                        tableBuilder.pool(
+                                LootPool.builder()
+                                        .rolls(ConstantLootNumberProvider.create(1f))
+                                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK).weight(5))
+                                        .apply(
+                                                EnchantRandomlyLootFunction.create()
+                                                        .add(SEnchantments.REHYDRATION)
+                                                        .build()
+                                        )
+                                        .with(ItemEntry.builder(Items.GOLDEN_CHESTPLATE).weight(25))
+                                        .apply(
+                                                EnchantRandomlyLootFunction.create()
+                                                        .add(SEnchantments.REHYDRATION)
+                                                        .build()
+                                        )
+                                        .with(EmptyEntry.builder().weight(429))
+                        );
+                    }
+                }
+        );
+
+        addToLoot(new Identifier("chests/nether_bridge"), 8f / 100f);
+    }
+
+    private static void addToLoot(Identifier lootTable, float chance) {
+        LootTableEvents.MODIFY.register(
+                (resourceManager, lootManager, id, tableBuilder, source) -> {
+                    if (source != LootTableSource.DATA_PACK && id.equals(lootTable)) {
+                        tableBuilder.pool(makeBuilder(chance));
+                    }
+                }
+        );
+    }
+
+    private static LootPool.Builder makeBuilder(float chance) {
+        return LootPool.builder()
+                .rolls(ConstantLootNumberProvider.create(1f))
+                .conditionally(RandomChanceLootCondition.builder(chance))
+                .with(ItemEntry.builder(Items.ENCHANTED_BOOK))
+                .apply(
+                        EnchantRandomlyLootFunction.create()
+                                .add(SEnchantments.REHYDRATION)
+                                .build()
+                );
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/enchantment/SEnchantmentHelper.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/enchantment/SEnchantmentHelper.java
@@ -4,6 +4,7 @@ import com.github.thedeathlycow.scorchful.registry.SEnchantments;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.MathHelper;
 
 public class SEnchantmentHelper {
 
@@ -11,25 +12,15 @@ public class SEnchantmentHelper {
         return EnchantmentHelper.getLevel(SEnchantments.REHYDRATION, stack);
     }
 
-    /**
-     * Gets the total {@linkplain SEnchantments#REHYDRATION rehydration} points for the player. The player gets 1 point
-     * for each piece of armour enchanted with Rehydration, and 1 point per level of Rehydration on that equipment.
-     * <p>
-     * For example if the player has Rehydration II on their helmet and Rehydration I on their chest plate, then they get
-     * 2 points from the helmet and chest plate, and 3 from the summed levels of the enchantments for a total of 5 points.
-     *
-     * @param player The player to get rehydration for
-     * @return Returns the total number of rehydration points. Returns 0 if they have no rehydration.
-     */
     public static int getTotalRehydrationForPlayer(PlayerEntity player) {
         int sum = 0;
         for (ItemStack stack : player.getArmorItems()) {
-            int rehydrationLevel = getRehydrationLevel(stack);
-
-            if (rehydrationLevel > 0) {
-                sum += rehydrationLevel + 1;
-            }
+            sum += getRehydrationLevel(stack);
         }
         return sum;
+    }
+
+    private SEnchantmentHelper() {
+
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/enchantment/SEnchantmentHelper.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/enchantment/SEnchantmentHelper.java
@@ -1,0 +1,35 @@
+package com.github.thedeathlycow.scorchful.enchantment;
+
+import com.github.thedeathlycow.scorchful.registry.SEnchantments;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+public class SEnchantmentHelper {
+
+    public static int getRehydrationLevel(ItemStack stack) {
+        return EnchantmentHelper.getLevel(SEnchantments.REHYDRATION, stack);
+    }
+
+    /**
+     * Gets the total {@linkplain SEnchantments#REHYDRATION rehydration} points for the player. The player gets 1 point
+     * for each piece of armour enchanted with Rehydration, and 1 point per level of Rehydration on that equipment.
+     * <p>
+     * For example if the player has Rehydration II on their helmet and Rehydration I on their chest plate, then they get
+     * 2 points from the helmet and chest plate, and 3 from the summed levels of the enchantments for a total of 5 points.
+     *
+     * @param player The player to get rehydration for
+     * @return Returns the total number of rehydration points. Returns 0 if they have no rehydration.
+     */
+    public static int getTotalRehydrationForPlayer(PlayerEntity player) {
+        int sum = 0;
+        for (ItemStack stack : player.getArmorItems()) {
+            int rehydrationLevel = getRehydrationLevel(stack);
+
+            if (rehydrationLevel > 0) {
+                sum += rehydrationLevel + 1;
+            }
+        }
+        return sum;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
@@ -8,9 +8,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.TagKey;
-import net.minecraft.text.Style;
 import net.minecraft.text.Text;
-import net.minecraft.text.TextColor;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -35,7 +33,7 @@ public class QuenchingFoods {
     public static void onConsume(LivingEntity user, ItemStack stack, @Nullable QuenchingLevel level) {
         if (level != null && user.isPlayer()) {
             ScorchfulComponents.PLAYER.get(user)
-                    .addWater(level.waterProvider.applyAsInt(Scorchful.getConfig().thirstConfig));
+                    .drink(level.waterProvider.applyAsInt(Scorchful.getConfig().thirstConfig));
         }
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/SArmorMaterials.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/SArmorMaterials.java
@@ -1,6 +1,5 @@
 package com.github.thedeathlycow.scorchful.item;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ArmorMaterial;
@@ -12,6 +11,7 @@ import net.minecraft.util.Util;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public enum SArmorMaterials implements ArmorMaterial {
 
@@ -33,12 +33,15 @@ public enum SArmorMaterials implements ArmorMaterial {
             0.0f,
             () -> Ingredient.ofItems(Items.WHEAT)
     );
-    private static final Map<ArmorItem.Type, Integer> BASE_DURABILITY = Util.make(new EnumMap<>(ArmorItem.Type.class), map -> {
-        map.put(ArmorItem.Type.BOOTS, 13);
-        map.put(ArmorItem.Type.LEGGINGS, 15);
-        map.put(ArmorItem.Type.CHESTPLATE, 16);
-        map.put(ArmorItem.Type.HELMET, 11);
-    });
+    private static final Map<ArmorItem.Type, Integer> BASE_DURABILITY = Util.make(
+            new EnumMap<>(ArmorItem.Type.class),
+            map -> {
+                map.put(ArmorItem.Type.BOOTS, 13);
+                map.put(ArmorItem.Type.LEGGINGS, 15);
+                map.put(ArmorItem.Type.CHESTPLATE, 16);
+                map.put(ArmorItem.Type.HELMET, 11);
+            }
+    );
     private final String name;
     private final int durabilityMultiplier;
     private final Map<ArmorItem.Type, Integer> protectionAmounts;
@@ -64,7 +67,7 @@ public enum SArmorMaterials implements ArmorMaterial {
         this.equipSound = equipSound;
         this.toughness = toughness;
         this.knockbackResistance = knockbackResistance;
-        this.repairIngredientSupplier = Suppliers.memoize(repairIngredientSupplier);
+        this.repairIngredientSupplier = Suppliers.memoize(repairIngredientSupplier::get);
     }
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SEnchantments.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SEnchantments.java
@@ -1,0 +1,25 @@
+package com.github.thedeathlycow.scorchful.registry;
+
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.enchantment.RehydrationEnchantment;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+
+public class SEnchantments {
+    private static final EquipmentSlot[] ALL_ARMOR = new EquipmentSlot[]{EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET};
+
+    public static final Enchantment REHYDRATION = new RehydrationEnchantment(Enchantment.Rarity.RARE, ALL_ARMOR);
+
+    public static void registerAll() {
+        register("rehydration", REHYDRATION);
+    }
+
+    private static void register(String name, Enchantment enchantment) {
+        Registry.register(Registries.ENCHANTMENT, Scorchful.id(name), enchantment);
+    }
+
+    private SEnchantments() {
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SSoundEvents.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SSoundEvents.java
@@ -8,11 +8,13 @@ import net.minecraft.sound.SoundEvent;
 public class SSoundEvents {
 
     public static final SoundEvent ITEM_WATER_SKIN_FILL = create("item.scorchful.water_skin.fill");
-    public static final SoundEvent TEMPERATURE_EFFECT_HEARTBEAT = create("thermoo.temperature_effect.scorchful.heartbeat");
+    public static final SoundEvent TEMPERATURE_EFFECT_HEARTBEAT = create("temperature_effect.scorchful.heartbeat");
+    public static final SoundEvent REHYDRATE = create("enchantment.scorchful.rehydration");
 
     public static void registerAll() {
         register(ITEM_WATER_SKIN_FILL);
         register(TEMPERATURE_EFFECT_HEARTBEAT);
+        register(REHYDRATE);
     }
 
     private static void register(SoundEvent event) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/ThirstCommand.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/ThirstCommand.java
@@ -2,10 +2,7 @@ package com.github.thedeathlycow.scorchful.server;
 
 import com.github.thedeathlycow.scorchful.components.ScorchfulComponents;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.minecraft.command.argument.EntityArgumentType;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.command.ServerCommandSource;
 
@@ -40,7 +37,7 @@ public class ThirstCommand {
             ServerCommandSource source,
             PlayerEntity target
     ) {
-        return ScorchfulComponents.PLAYER.get(target).getWater();
+        return ScorchfulComponents.PLAYER.get(target).getWaterDrunk();
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.scorchful.temperature;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.components.ScorchfulComponents;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import com.github.thedeathlycow.scorchful.mixin.thirst.EntityInvoker;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
@@ -82,6 +83,10 @@ public class WetTickController extends EnvironmentControllerDecorator {
             // add wetness when touching, but not submerged in, water
             if (entity.isTouchingWater() || entity.getBlockStateAtPos().isOf(Blocks.WATER_CAULDRON)) {
                 soakChange += config.thirstConfig.getTouchingWaterWetnessIncrease();
+            }
+
+            if (soakChange < 0) {
+                ScorchfulComponents.PLAYER.get(this).tickRehydration(config.thirstConfig);
             }
 
             return soakChange;

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -47,6 +47,10 @@ public class WetTickController extends EnvironmentControllerDecorator {
                 soakChange -= config.thirstConfig.getOnFireDryDate();
             }
 
+            if (soakChange < 0 && entity.isPlayer()) {
+                ScorchfulComponents.PLAYER.get(entity).tickRehydration(config.thirstConfig);
+            }
+
             return soakChange;
         }
     }
@@ -83,10 +87,6 @@ public class WetTickController extends EnvironmentControllerDecorator {
             // add wetness when touching, but not submerged in, water
             if (entity.isTouchingWater() || entity.getBlockStateAtPos().isOf(Blocks.WATER_CAULDRON)) {
                 soakChange += config.thirstConfig.getTouchingWaterWetnessIncrease();
-            }
-
-            if (soakChange < 0) {
-                ScorchfulComponents.PLAYER.get(this).tickRehydration(config.thirstConfig);
             }
 
             return soakChange;

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -69,6 +69,11 @@ public class WetTickController extends EnvironmentControllerDecorator {
             EntityInvoker invoker = (EntityInvoker) entity;
 
 
+            // immediately soak players in water
+            if (entity.isSubmergedInWater() || invoker.scorchful_invokeIsInsideBubbleColumn()) {
+                return entity.thermoo$getMaxWetTicks();
+            }
+
             // add wetness from rain
             if (invoker.scorchful_invokeIsBeingRainedOn()) {
                 soakChange += config.thirstConfig.getRainWetnessIncrease();
@@ -77,11 +82,6 @@ public class WetTickController extends EnvironmentControllerDecorator {
             // add wetness when touching, but not submerged in, water
             if (entity.isTouchingWater() || entity.getBlockStateAtPos().isOf(Blocks.WATER_CAULDRON)) {
                 soakChange += config.thirstConfig.getTouchingWaterWetnessIncrease();
-            }
-
-            // immediately soak players in water
-            if (entity.isSubmergedInWater() || invoker.scorchful_invokeIsInsideBubbleColumn()) {
-                soakChange = entity.thermoo$getMaxWetTicks();
             }
 
             return soakChange;

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -47,6 +47,7 @@
     "text.autoconfig.scorchful.option.thirstConfig.waterFromRefreshingFood": "Water from Refreshing food",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromSustainingFood": "Water from Sustaining food",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromHydratingFood": "Water from Hydrating food",
+    "text.autoconfig.scorchful.option.thirstConfig.rehydrationDrinkSize": "Rehydration drink size",
     "text.autoconfig.scorchful.option.thirstConfig.soakingFromSplashPotions": "Soaking from Splash Potions",
     "text.autoconfig.scorchful.option.thirstConfig.rainWetnessIncrease": "Rain wetness increase per tick",
     "text.autoconfig.scorchful.option.thirstConfig.touchingWaterWetnessIncrease": "Touching water wetness increase per tick",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -43,7 +43,6 @@
     "text.autoconfig.scorchful.option.heatingConfig.fireballHeat": "Fireball strike heat",
     
     "text.autoconfig.scorchful.option.thirstConfig": "Thirst Config",
-    "text.autoconfig.scorchful.option.thirstConfig.wetnessFromBodyWater": "Wetness from Body Water",
     "text.autoconfig.scorchful.option.thirstConfig.temperatureFromWetness": "Temperature from Wetness",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromRefreshingFood": "Water from Refreshing food",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromSustainingFood": "Water from Sustaining food",
@@ -54,6 +53,8 @@
     "text.autoconfig.scorchful.option.thirstConfig.dryRate": "Dry rate",
     "text.autoconfig.scorchful.option.thirstConfig.onFireDryDate": "On fire dry rate",
     "text.autoconfig.scorchful.option.thirstConfig.humidBiomeSweatEfficiency": "Humid biome sweating efficiency",
+    "text.autoconfig.scorchful.option.thirstConfig.minRehydrationEfficiency": "Minimum Rehydration Enchantment efficiency",
+    "text.autoconfig.scorchful.option.thirstConfig.maxRehydrationEfficiency": "Maximum Rehydration Enchantment efficiency",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -15,11 +15,18 @@
     "item.scorchful.tooltip.sustaining": "Sustaining \uD83C\uDF0A\uD83C\uDF0A",
     "item.scorchful.tooltip.hydrating": "Hydrating \uD83C\uDF0A\uD83C\uDF0A\uD83C\uDF0A",
     
+    
+    "enchantment.scorchful.rehydration": "Rehydration",
+    "enchantment.scorchful.rehydration.desc": "Replenishes body water lost from sweating",
+    
+    
     "death.attack.scorchful.heat": "%1$s couldn't handle the heat",
     "death.attack.scorchful.heat.player": "%1$s couldn't handle the heat of %2$s",
     
+    
     "subtitles.item.scorchful.water_skin.fill": "Waterskin fills",
     "subtitles.thermoo.temperature_effect.scorchful.heartbeat": "Heart beats",
+    
     
     "text.autoconfig.scorchful.option.clientConfig": "Client Config",
     "text.autoconfig.scorchful.option.clientConfig.doBurningHeartOverlay": "Do burning heart overlay",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -53,7 +53,6 @@
     "text.autoconfig.scorchful.option.thirstConfig.dryRate": "Dry rate",
     "text.autoconfig.scorchful.option.thirstConfig.onFireDryDate": "On fire dry rate",
     "text.autoconfig.scorchful.option.thirstConfig.humidBiomeSweatEfficiency": "Humid biome sweating efficiency",
-    "text.autoconfig.scorchful.option.thirstConfig.minRehydrationEfficiency": "Minimum Rehydration Enchantment efficiency",
     "text.autoconfig.scorchful.option.thirstConfig.maxRehydrationEfficiency": "Maximum Rehydration Enchantment efficiency",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -25,7 +25,8 @@
     
     
     "subtitles.item.scorchful.water_skin.fill": "Waterskin fills",
-    "subtitles.thermoo.temperature_effect.scorchful.heartbeat": "Heart beats",
+    "subtitles.temperature_effect.scorchful.heartbeat": "Heart beats",
+    "subtitles.enchantment.scorchful.rehydration": "Player Rehydrates",
     
     
     "text.autoconfig.scorchful.option.clientConfig": "Client Config",

--- a/src/main/resources/assets/scorchful/sounds.json
+++ b/src/main/resources/assets/scorchful/sounds.json
@@ -8,10 +8,19 @@
         ],
         "subtitle": "subtitles.item.scorchful.water_skin.fill"
     },
-    "thermoo.temperature_effect.scorchful.heartbeat": {
+    "temperature_effect.scorchful.heartbeat": {
         "sounds": [
             "scorchful:entity/heartbeat"
         ],
-        "subtitle": "subtitles.thermoo.temperature_effect.scorchful.heartbeat"
+        "subtitle": "subtitles.temperature_effect.scorchful.heartbeat"
+    },
+    "enchantment.scorchful.rehydration": {
+        "sounds": [
+            "item/bottle/fill1",
+            "item/bottle/fill2",
+            "item/bottle/fill3",
+            "item/bottle/fill4"
+        ],
+        "subtitle": "subtitles.enchantment.scorchful.rehydration"
     }
 }

--- a/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_fast.json
+++ b/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_fast.json
@@ -10,7 +10,7 @@
     },
     "config": {
         "interval": 6,
-        "sound": "scorchful:thermoo.temperature_effect.scorchful.heartbeat",
+        "sound": "scorchful:temperature_effect.scorchful.heartbeat",
         "volume": 1,
         "pitch": 1,
         "only_play_to_source": true

--- a/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_medium.json
+++ b/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_medium.json
@@ -11,7 +11,7 @@
     },
     "config": {
         "interval": 11,
-        "sound": "scorchful:thermoo.temperature_effect.scorchful.heartbeat",
+        "sound": "scorchful:temperature_effect.scorchful.heartbeat",
         "volume": 1,
         "pitch": 1,
         "only_play_to_source": true

--- a/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_slow.json
+++ b/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_slow.json
@@ -11,7 +11,7 @@
     },
     "config": {
         "interval": 22,
-        "sound": "scorchful:thermoo.temperature_effect.scorchful.heartbeat",
+        "sound": "scorchful:temperature_effect.scorchful.heartbeat",
         "volume": 1,
         "pitch": 1,
         "only_play_to_source": true

--- a/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_very_slow.json
+++ b/src/main/resources/data/scorchful/thermoo/temperature_effects/heartbeat_very_slow.json
@@ -11,7 +11,7 @@
     },
     "config": {
         "interval": 66,
-        "sound": "scorchful:thermoo.temperature_effect.scorchful.heartbeat",
+        "sound": "scorchful:temperature_effect.scorchful.heartbeat",
         "volume": 1,
         "pitch": 1,
         "only_play_to_source": true


### PR DESCRIPTION
Adds the Rehydration enchantment to armor. Rehydration works by slowly building up a 'drink' from water lost to sweating. When the drink reaches its maximum capacity, it is consumed by the player with accompanying sounds and particle effects (unless the player is sneaking/silenced or invisible). The amount consumed from the drink is a percentage based on the total combined level of all Rehydration enchanted armour currently being worn.

Closes #6 