### PR TITLE
Balance Update 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.2
+mod_version=0.3
 maven_group=com.github.thedeathlycow
 archives_base_name=scorchful
 

--- a/src/client/java/com/github/thedeathlycow/scorchful/hud/ShadeOverlay.java
+++ b/src/client/java/com/github/thedeathlycow/scorchful/hud/ShadeOverlay.java
@@ -21,9 +21,7 @@ public class ShadeOverlay {
             @Nullable ClientPlayerEntity player,
             BiConsumer<DrawContext, Float> renderCallback
     ) {
-
-
-        if (player != null && SunHatItem.isWearingSunHat(player)) {
+        if (player != null && !player.isUsingSpyglass() && SunHatItem.isWearingSunHat(player)) {
             ClientConfig config = Scorchful.getConfig().clientConfig;
             if (config.isSunHatShading()) {
                 renderCallback.accept(context, config.getSunHatShadeOpacity());

--- a/src/client/java/com/github/thedeathlycow/scorchful/mixin/client/InGameHudMixin.java
+++ b/src/client/java/com/github/thedeathlycow/scorchful/mixin/client/InGameHudMixin.java
@@ -32,9 +32,7 @@ public abstract class InGameHudMixin {
         ShadeOverlay.renderShadeOverlay(
                 context,
                 client.player,
-                (ctx, opacity) -> {
-                    this.renderOverlay(ctx, ShadeOverlay.SHADE_OVERLAY, opacity);
-                }
+                (ctx, opacity) -> this.renderOverlay(ctx, ShadeOverlay.SHADE_OVERLAY, opacity)
         );
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -32,7 +32,7 @@ public class Scorchful implements ModInitializer {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
 
-    public static final int CONFIG_VERSION = 3;
+    public static final int CONFIG_VERSION = 4;
 
     @Contract("_->new")
     public static Identifier id(String path) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -79,24 +79,12 @@ public class PlayerComponent implements Component, ServerTickingComponent {
 
     private void tickWater(PlayerEntity player) {
         ScorchfulConfig config = Scorchful.getConfig();
-        ThirstConfig thirstConfig = config.thirstConfig;
 
         // sweating: move body water to wetness
         if (ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.DEHYDRATION_ID)) {
             this.tickSweatDehydration(config.integrationConfig, player);
         } else {
             this.tickSweatNormal(player);
-        }
-
-        // cooling: move wetness to temperature
-        if (player.thermoo$isWet()) {
-            int temperatureChange = MathHelper.floor(thirstConfig.getTemperatureFromWetness() * player.thermoo$getSoakedScale());
-            World world = player.getWorld();
-            if (world.getBiome(player.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
-                temperatureChange = MathHelper.floor(temperatureChange * thirstConfig.getHumidBiomeSweatEfficiency());
-            }
-
-            player.thermoo$addTemperature(temperatureChange);
         }
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
@@ -25,6 +25,8 @@ public class HeatingConfig implements ConfigData {
 
     int onFireWarmRate = 24;
 
+    int onFireWarmRateWithFireResistance = 6;
+
     int powderSnowCoolRate = 24;
 
     int fireballHeat = 1000;
@@ -79,6 +81,10 @@ public class HeatingConfig implements ConfigData {
 
     public int getOnFireWarmRate() {
         return onFireWarmRate;
+    }
+
+    public int getOnFireWarmRateWithFireResistance() {
+        return onFireWarmRateWithFireResistance;
     }
 
     public int getPowderSnowCoolRate() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
@@ -39,6 +39,12 @@ public class HeatingConfig implements ConfigData {
 
     int waterBreathingDurationPerTurtleArmorPieceSeconds = 10;
 
+    int lightLevelPerHeatInNether = 4;
+
+    int blocksAboveLavaOceanPerHeatInNether = 5;
+
+    int maxHeatFromLavaOceanInNether = 3;
+
     public boolean doPassiveHeating() {
         return doPassiveHeating;
     }
@@ -101,5 +107,17 @@ public class HeatingConfig implements ConfigData {
 
     public int getWaterBreathingDurationPerTurtleArmorPieceSeconds() {
         return waterBreathingDurationPerTurtleArmorPieceSeconds;
+    }
+
+    public int getLightLevelPerHeatInNether() {
+        return lightLevelPerHeatInNether;
+    }
+
+    public int getBlocksAboveLavaOceanPerHeatInNether() {
+        return blocksAboveLavaOceanPerHeatInNether;
+    }
+
+    public int getMaxHeatFromLavaOceanInNether() {
+        return maxHeatFromLavaOceanInNether;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
@@ -10,6 +10,9 @@ import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
 
     @ConfigEntry.Gui.CollapsibleObject
+    public UpdateConfig updateConfig = new UpdateConfig();
+
+    @ConfigEntry.Gui.CollapsibleObject
     public ClientConfig clientConfig = new ClientConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
@@ -23,9 +26,6 @@ public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
 
     @ConfigEntry.Gui.CollapsibleObject
     public ModIntegrationConfig integrationConfig = new ModIntegrationConfig();
-
-    @ConfigEntry.Gui.CollapsibleObject
-    public UpdateConfig updateConfig = new UpdateConfig();
 
     public static void updateConfig(ConfigHolder<ScorchfulConfig> configHolder) {
         UpdateConfig config = configHolder.getConfig().updateConfig;

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -23,7 +23,7 @@ public class ThirstConfig implements ConfigData {
 
     int dryRate = 1;
 
-    int onFireDryDate = 50;
+    int onFireDryDate = 3;
 
     float humidBiomeSweatEfficiency = 1f / 6f;
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -7,7 +7,7 @@ import me.shedaniel.autoconfig.annotation.Config;
 @Config(name = Scorchful.MODID + ".thirst_config")
 public class ThirstConfig implements ConfigData {
 
-    int temperatureFromWetness = -12;
+    int temperatureFromWetness = -6;
 
     int waterFromRefreshingFood = 60;
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/mixin/LivingEntityMixin.java
@@ -2,6 +2,7 @@ package com.github.thedeathlycow.scorchful.mixin;
 
 import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
 import com.github.thedeathlycow.scorchful.server.SandstormSlowing;
+import com.github.thedeathlycow.scorchful.temperature.Cooling;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -46,6 +47,17 @@ public abstract class LivingEntityMixin extends Entity {
                 (LivingEntity) (Object) this,
                 scorchful_wasInSandstorm
         );
+        profiler.pop();
+    }
+
+    @Inject(
+            method = "tick",
+            at = @At("TAIL")
+    )
+    private void afterTick(CallbackInfo ci) {
+        Profiler profiler = this.getWorld().getProfiler();
+        profiler.push("scorchful_cooling");
+        Cooling.tick((LivingEntity) (Object) this);
         profiler.pop();
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
@@ -11,7 +11,6 @@ import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerChunkManager;
@@ -22,11 +21,6 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.dimension.DimensionType;
 
 public class AmbientTemperatureController extends EnvironmentControllerDecorator {
-
-
-    private static final int BLOCK_LIGHT_DIVISOR = 4;
-    private static final int HEAT_HEIGHT_SLOPE = -5;
-    private static final int MAX_HEAT_FROM_HEIGHT = 3;
 
     private static final int SKY_LIGHT_BELOW_FOR_SHADE = 2;
 
@@ -125,11 +119,14 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
             distanceToLavaLevel = Math.max(height - seaLevel, 0);
         }
 
+        HeatingConfig config = Scorchful.getConfig().heatingConfig;
+        int maxHeatFromHeight = config.getMaxHeatFromLavaOceanInNether();
+
         return Math.max(
-                blockLight / BLOCK_LIGHT_DIVISOR,
+                blockLight / config.getLightLevelPerHeatInNether(),
                 distanceToLavaLevel != 0
-                        ? ((distanceToLavaLevel / HEAT_HEIGHT_SLOPE) + MAX_HEAT_FROM_HEIGHT)
-                        : MAX_HEAT_FROM_HEIGHT
+                        ? ((distanceToLavaLevel / -config.getBlocksAboveLavaOceanPerHeatInNether()) + maxHeatFromHeight)
+                        : maxHeatFromHeight
         );
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
@@ -11,6 +11,7 @@ import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerChunkManager;
@@ -46,8 +47,12 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
         int change = 0;
         HeatingConfig config = Scorchful.getConfig().heatingConfig;
 
-        if (entity.isOnFire() && !entity.isFireImmune()) {
-            change += config.getOnFireWarmRate();
+        if (entity.thermoo$canOverheat() && entity.isOnFire() && !entity.isFireImmune()) {
+            int onFireChange = entity.hasStatusEffect(StatusEffects.FIRE_RESISTANCE)
+                    ? config.getOnFireWarmRateWithFireResistance()
+                    : config.getOnFireWarmRate();
+
+            change += onFireChange;
         }
 
         if (entity.wasInPowderSnow && entity.thermoo$canFreeze()) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
@@ -52,7 +52,7 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
         int change = 0;
         HeatingConfig config = Scorchful.getConfig().heatingConfig;
 
-        if (entity.isOnFire() && !entity.isFireImmune() && !entity.hasStatusEffect(StatusEffects.FIRE_RESISTANCE)) {
+        if (entity.isOnFire() && !entity.isFireImmune()) {
             change += config.getOnFireWarmRate();
         }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -14,9 +14,7 @@ public class Cooling {
         if (entity.thermoo$getTemperature() > 0 && entity.thermoo$isWet()) {
             ThirstConfig config = Scorchful.getConfig().thirstConfig;
 
-            int temperatureChange = MathHelper.floor(
-                    config.getTemperatureFromWetness() * entity.thermoo$getSoakedScale()
-            );
+            int temperatureChange = config.getTemperatureFromWetness();
             World world = entity.getWorld();
             if (world.getBiome(entity.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
                 temperatureChange = MathHelper.floor(temperatureChange * config.getHumidBiomeSweatEfficiency());

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -1,0 +1,33 @@
+package com.github.thedeathlycow.scorchful.temperature;
+
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
+import com.github.thedeathlycow.scorchful.config.ThirstConfig;
+import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+
+public class Cooling {
+
+    public static void tick(LivingEntity entity) {
+        if (entity.thermoo$getTemperature() > 0 && entity.thermoo$isWet()) {
+            ThirstConfig config = Scorchful.getConfig().thirstConfig;
+
+            int temperatureChange = MathHelper.floor(
+                    config.getTemperatureFromWetness() * entity.thermoo$getSoakedScale()
+            );
+            World world = entity.getWorld();
+            if (world.getBiome(entity.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
+                temperatureChange = MathHelper.floor(temperatureChange * config.getHumidBiomeSweatEfficiency());
+            }
+
+            entity.thermoo$addTemperature(temperatureChange);
+        }
+    }
+
+    private Cooling() {
+
+    }
+
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -47,7 +47,7 @@ public class WetTickController extends EnvironmentControllerDecorator {
             wetChange -= config.thirstConfig.getOnFireDryDate();
         }
 
-        if (wetChange < 0 && entity.isPlayer() && entity.isWet()) {
+        if (wetChange < 0 && entity.isPlayer() && entity.thermoo$isWet()) {
             ScorchfulComponents.PLAYER.get(entity).tickRehydration(config.thirstConfig);
         }
 

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -79,6 +79,7 @@
     "text.autoconfig.scorchful.option.heatingConfig.scorchingBiomeHeatIncrease": "Scorching biome heat increase",
     "text.autoconfig.scorchful.option.heatingConfig.sunHatShadeTemperatureChange": "Sun Hat",
     "text.autoconfig.scorchful.option.heatingConfig.onFireWarmRate": "On fire warm rate",
+    "text.autoconfig.scorchful.option.heatingConfig.onFireWarmRateWithFireResistance": "On fire warm rate with Fire Resistance",
     "text.autoconfig.scorchful.option.heatingConfig.powderSnowCoolRate": "Powder Snow cool rate when warm",
     "text.autoconfig.scorchful.option.heatingConfig.fireballHeat": "Fireball strike heat",
     "text.autoconfig.scorchful.option.heatingConfig.defaultArmorHeatResistance": "Default armor piece heat resistance",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -86,6 +86,9 @@
     "text.autoconfig.scorchful.option.heatingConfig.protectiveArmorHeatResistance": "Thermally protective armor piece heat resistance",
     "text.autoconfig.scorchful.option.heatingConfig.veryProtectiveArmorHeatResistance": "Very thermally protective armor piece heat resistance",
     "text.autoconfig.scorchful.option.heatingConfig.waterBreathingDurationPerTurtleArmorPieceSeconds": "Water breathing duration per worn piece of Turtle Armor (seconds)",
+    "text.autoconfig.scorchful.option.heatingConfig.lightLevelPerHeatInNether": "Light level per heat increase (in The Nether)",
+    "text.autoconfig.scorchful.option.heatingConfig.blocksAboveLavaOceanPerHeatInNether": "Blocks above Lava Ocean per heat increase (in The Nether)",
+    "text.autoconfig.scorchful.option.heatingConfig.maxHeatFromLavaOceanInNether": "Maximum heat from Lava Ocean (in The Nether)",
     
     "text.autoconfig.scorchful.option.thirstConfig": "Thirst Config",
     "text.autoconfig.scorchful.option.thirstConfig.temperatureFromWetness": "Temperature from Wetness",

--- a/src/main/resources/data/scorchful/predicates/is_nausea_affected.json
+++ b/src/main/resources/data/scorchful/predicates/is_nausea_affected.json
@@ -1,0 +1,25 @@
+{
+    "condition": "minecraft:all_of",
+    "terms": [
+        {
+            "condition": "minecraft:reference",
+            "name": "scorchful:can_heat"
+        },
+        {
+            "condition": "minecraft:inverted",
+            "term": {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                    "effects": {
+                        "minecraft:fire_resistance": {
+                            "duration": {
+                                "min": 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/thermoo/temperature_effects/nausea.json
+++ b/src/main/resources/data/scorchful/thermoo/temperature_effects/nausea.json
@@ -2,7 +2,7 @@
     "type": "thermoo:status_effect",
     "entity": {
         "condition": "minecraft:reference",
-        "name": "scorchful:can_heat"
+        "name": "scorchful:is_nausea_affected"
     },
     "entity_type": "minecraft:player",
     "temperature_scale_range": {
@@ -11,14 +11,9 @@
     "config": {
         "effects": [
             {
-                "amplifier": 1,
-                "duration": 20,
-                "effect": "minecraft:hunger"
-            },
-            {
-                "amplifier": 1,
-                "duration": 20,
-                "effect": "minecraft:weakness"
+                "amplifier": 0,
+                "duration": 200,
+                "effect": "minecraft:nausea"
             }
         ]
     }


### PR DESCRIPTION
A second balancing update, this time a bit more focused on the Nether and later game. This is probably not going to be the last balance update, but hopefully now things are generally a bit more okay. Note that this update changes a few default config values, and **the config will reset itself if automatic updates are not disabled!**

* Cooling is now applied to all living entities (Fixes #34)
* Fixed Rehydration not ticking properly 
* Fixed screen going completely black when using a Spyglass and wearing a Sun Hat (Fixes #35)
* No longer scale cooling by wetness percent (this made it too hard to tell whether or not drinking actually did anything)
* Nausea is no longer applied at max heat when the player has fire resistance
* Added config values for heating in The Nether
* Added a separate configurable on fire warm rate with Fire Resistance, which is set to a quarter of the normal on fire rate by default 

# Config Version 4 

* Reduced cooling from wetness to -6 from -12
* Reduced drying per tick from being on fire from 50 to 3
