### PR TITLE
Version 0.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.4-SNAPSHOT
+mod_version=0.4
 maven_group=com.github.thedeathlycow
 archives_base_name=scorchful
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.3
+mod_version=0.4-SNAPSHOT
 maven_group=com.github.thedeathlycow
 archives_base_name=scorchful
 

--- a/src/client/java/com/github/thedeathlycow/scorchful/entity/model/SunHatModel.java
+++ b/src/client/java/com/github/thedeathlycow/scorchful/entity/model/SunHatModel.java
@@ -25,7 +25,7 @@ public class SunHatModel<T extends LivingEntity> extends BipedEntityModel<T> {
                 ModelPartBuilder.create()
                         .uv(0, 0)
                         .cuboid(
-                                -8.0F, -5.0F, -8.0F,
+                                -8.0F, -4.5F, -8.0F,
                                 16.0F, 0.0F, 16.0F,
                                 dilation.add(0.1f, 0f, 0.1f)
                         )

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -5,6 +5,7 @@ import com.github.thedeathlycow.scorchful.block.SandCauldronBehaviours;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import com.github.thedeathlycow.scorchful.enchantment.RehydrationEnchantment;
 import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
+import com.github.thedeathlycow.scorchful.item.FireChargeThrower;
 import com.github.thedeathlycow.scorchful.item.HeatResistantArmourTagApplicator;
 import com.github.thedeathlycow.scorchful.registry.*;
 import com.github.thedeathlycow.scorchful.server.ThirstCommand;
@@ -19,6 +20,7 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.fabricmc.fabric.api.item.v1.ModifyItemAttributeModifiersCallback;
 import net.minecraft.entity.damage.DamageTypes;
 import net.minecraft.util.Identifier;
@@ -62,6 +64,7 @@ public class Scorchful implements ModInitializer {
                     ThirstCommand.register(dispatcher);
                 }
         );
+        UseItemCallback.EVENT.register(new FireChargeThrower());
         ModifyItemAttributeModifiersCallback.EVENT.register(new HeatResistantArmourTagApplicator());
 
         // custom scorchful event

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/ScorchfulIntegrations.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/ScorchfulIntegrations.java
@@ -20,7 +20,7 @@ public class ScorchfulIntegrations {
         return isModLoaded(COLORFUL_HEARTS_ID) || isModLoaded(OVERFLOWING_BARS_ID);
     }
 
-    public static boolean isThirstModLoaded() {
+    public static boolean isDehydrationLoaded() {
         return isModLoaded(DEHYDRATION_ID);
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -77,7 +77,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
         ScorchfulConfig config = Scorchful.getConfig();
 
         // sweating: move body water to wetness
-        if (ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.DEHYDRATION_ID)) {
+        if (ScorchfulIntegrations.isDehydrationLoaded()) {
             this.tickSweatDehydration(config.integrationConfig.dehydrationConfig, player);
         } else {
             this.tickSweatNormal(player);

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -107,12 +107,12 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     // However, some of that water is lost, based on the total level of Rehydration.
 
     public void tickRehydrationWaterRecapture(ScorchfulConfig config, boolean dehydrationLoaded) {
-        int rehydrationCapacity = getRehydrationDrinkSize(config, dehydrationLoaded);
+        int rehydrationCapacity = config.getRehydrationDrinkSize(dehydrationLoaded);
         this.rehydrationDrink = Math.min(this.rehydrationDrink + 1, rehydrationCapacity);
     }
 
     public void tickRehydration(ScorchfulConfig config, int rehydrationLevel, boolean dehydrationLoaded) {
-        int rehydrationCapacity = getRehydrationDrinkSize(config, dehydrationLoaded);
+        int rehydrationCapacity = config.getRehydrationDrinkSize(dehydrationLoaded);
         if (rehydrationDrink >= rehydrationCapacity) {
             if (dehydrationLoaded) {
                 this.rehydrateWithDehydration(config, rehydrationLevel);
@@ -155,7 +155,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
         }
 
         int waterToAdd = this.provider.getRandom()
-                .nextBetween(0, rehydrationLevel * dehydrationConfig.getRehydrationWaterAddedPerLevel());
+                .nextBetween(0, rehydrationLevel * dehydrationConfig.getMaxRehydrationWaterAddedPerLevel());
 
         if (this.provider.getWorld() instanceof ServerWorld serverWorld) {
             thirstManager.add(waterToAdd);
@@ -192,11 +192,5 @@ public class PlayerComponent implements Component, ServerTickingComponent {
 
     private static float getRehydrationEfficiency(int rehydrationLevel, float min, float max) {
         return MathHelper.lerp(rehydrationLevel / 4f, min, max);
-    }
-
-    private static int getRehydrationDrinkSize(ScorchfulConfig config, boolean dehydrationLoaded) {
-        return dehydrationLoaded
-                ? config.integrationConfig.dehydrationConfig.getRehydrationDrinkSize()
-                : config.thirstConfig.getRehydrationDrinkSize();
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -154,9 +154,10 @@ public class PlayerComponent implements Component, ServerTickingComponent {
             return;
         }
 
-        int waterToAdd = rehydrationLevel * dehydrationConfig.getRehydrationWaterAddedPerLevel();
+        int waterToAdd = this.provider.getRandom()
+                .nextBetween(0, rehydrationLevel * dehydrationConfig.getRehydrationWaterAddedPerLevel());
 
-        if (waterToAdd > 0 && this.provider.getWorld() instanceof ServerWorld serverWorld) {
+        if (this.provider.getWorld() instanceof ServerWorld serverWorld) {
             thirstManager.add(waterToAdd);
             this.playRehydrationEffects(serverWorld);
             this.resetRehydration();
@@ -195,7 +196,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
 
     private static int getRehydrationDrinkSize(ScorchfulConfig config, boolean dehydrationLoaded) {
         return dehydrationLoaded
-                ? config.thirstConfig.getRehydrationDrinkSize()
-                : config.integrationConfig.dehydrationConfig.getRehydrationDrinkSize();
+                ? config.integrationConfig.dehydrationConfig.getRehydrationDrinkSize()
+                : config.thirstConfig.getRehydrationDrinkSize();
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/components/PlayerComponent.java
@@ -78,7 +78,7 @@ public class PlayerComponent implements Component, ServerTickingComponent {
 
         // sweating: move body water to wetness
         if (ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.DEHYDRATION_ID)) {
-            this.tickSweatDehydration(config.dehydrationConfig, player);
+            this.tickSweatDehydration(config.integrationConfig.dehydrationConfig, player);
         } else {
             this.tickSweatNormal(player);
         }
@@ -148,12 +148,13 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     private void rehydrateWithDehydration(ScorchfulConfig config, int rehydrationLevel) {
         ThirstManager thirstManager = ((ThirstManagerAccess) this.provider).getThirstManager();
 
+        DehydrationConfig dehydrationConfig = config.integrationConfig.dehydrationConfig;
         // dont drink if dont have to - prevents rehydration spam
-        if (thirstManager.getThirstLevel() > config.dehydrationConfig.getMinWaterLevelToRehydrate()) {
+        if (thirstManager.getThirstLevel() > dehydrationConfig.getMinWaterLevelForSweat()) {
             return;
         }
 
-        int waterToAdd = rehydrationLevel * config.dehydrationConfig.getRehydrationWaterAddedPerLevel();
+        int waterToAdd = rehydrationLevel * dehydrationConfig.getRehydrationWaterAddedPerLevel();
 
         if (waterToAdd > 0 && this.provider.getWorld() instanceof ServerWorld serverWorld) {
             thirstManager.add(waterToAdd);
@@ -195,6 +196,6 @@ public class PlayerComponent implements Component, ServerTickingComponent {
     private static int getRehydrationDrinkSize(ScorchfulConfig config, boolean dehydrationLoaded) {
         return dehydrationLoaded
                 ? config.thirstConfig.getRehydrationDrinkSize()
-                : config.dehydrationConfig.getRehydrationDrinkSizeDehydration();
+                : config.integrationConfig.dehydrationConfig.getRehydrationDrinkSize();
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
@@ -1,0 +1,16 @@
+package com.github.thedeathlycow.scorchful.config;
+
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.item.FireChargeThrower;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+
+@Config(name = Scorchful.MODID + ".combat_config")
+public class CombatConfig implements ConfigData {
+
+    FireChargeThrower.FireballFactory fireBallThrownType = FireChargeThrower.FireballFactory.SMALL;
+
+    public FireChargeThrower.FireballFactory getFireBallThrownType() {
+        return fireBallThrownType;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
@@ -4,10 +4,12 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.item.FireChargeThrower;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 @Config(name = Scorchful.MODID + ".combat_config")
 public class CombatConfig implements ConfigData {
 
+    @ConfigEntry.Gui.EnumHandler
     FireChargeThrower.FireballFactory fireBallThrownType = FireChargeThrower.FireballFactory.SMALL;
 
     public FireChargeThrower.FireballFactory getFireBallThrownType() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
@@ -4,8 +4,8 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 
-@Config(name = Scorchful.MODID + ".modIntegrationConfig")
-public class ModIntegrationConfig implements ConfigData {
+@Config(name = Scorchful.MODID + ".dehydrationConfig")
+public class DehydrationConfig implements ConfigData {
 
     /**
      * Requires Dehydration
@@ -17,7 +17,7 @@ public class ModIntegrationConfig implements ConfigData {
      * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
      * quarter of the direct equivalent draining speed.
      */
-    float dehydrationConsumedBySweat = 1f / 30f;
+    float dehydrationConsumedBySweat = 0.5f / 30f;
 
     /**
      * Requires Dehydration
@@ -29,12 +29,14 @@ public class ModIntegrationConfig implements ConfigData {
     /**
      * Requires Dehydration
      */
-    int maxThirstAddedByRehydration = 4;
+    int rehydrationWaterAddedPerLevel = 1;
 
     /**
      * Requires Dehydration
      */
-    int minWaterLevelToRehydrate = 10;
+    int minWaterLevelToRehydrate = 14;
+
+    int rehydrationDrinkSizeDehydration = 1000;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;
@@ -44,11 +46,15 @@ public class ModIntegrationConfig implements ConfigData {
         return minWaterLevelForSweat;
     }
 
-    public int getMaxThirstAddedByRehydration() {
-        return maxThirstAddedByRehydration;
+    public int getRehydrationWaterAddedPerLevel() {
+        return rehydrationWaterAddedPerLevel;
     }
 
     public int getMinWaterLevelToRehydrate() {
         return minWaterLevelToRehydrate;
+    }
+
+    public int getRehydrationDrinkSizeDehydration() {
+        return rehydrationDrinkSizeDehydration;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
@@ -4,12 +4,13 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 
+/**
+ * Config for changes to thirst system when using Dehydration
+ */
 @Config(name = Scorchful.MODID + ".dehydrationConfig")
 public class DehydrationConfig implements ConfigData {
 
     /**
-     * Requires Dehydration
-     * <p>
      * A direct equivalent would be set this to 8/30:
      * 4 dehydration points reduces water level by 1, and
      * water level is out of 20 * 4 = 80, while waterDrunk is out of 300, so 1 water level is 2/30 of waterDrunk
@@ -20,23 +21,15 @@ public class DehydrationConfig implements ConfigData {
     float dehydrationConsumedBySweat = 0.5f / 30f;
 
     /**
-     * Requires Dehydration
-     * <p>
      * Don't lose water to sweat when below this level.
      */
     int minWaterLevelForSweat = 16;
 
-    /**
-     * Requires Dehydration
-     */
     int rehydrationWaterAddedPerLevel = 1;
 
-    /**
-     * Requires Dehydration
-     */
-    int minWaterLevelToRehydrate = 14;
+    int rehydrationDrinkSize = 1000;
 
-    int rehydrationDrinkSizeDehydration = 1000;
+    int temperaturePerWetness = 3;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;
@@ -50,11 +43,11 @@ public class DehydrationConfig implements ConfigData {
         return rehydrationWaterAddedPerLevel;
     }
 
-    public int getMinWaterLevelToRehydrate() {
-        return minWaterLevelToRehydrate;
+    public int getRehydrationDrinkSize() {
+        return rehydrationDrinkSize;
     }
 
-    public int getRehydrationDrinkSizeDehydration() {
-        return rehydrationDrinkSizeDehydration;
+    public int getTemperaturePerWetness() {
+        return temperaturePerWetness;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
@@ -29,7 +29,7 @@ public class DehydrationConfig implements ConfigData {
 
     int rehydrationDrinkSize = 300;
 
-    int temperatureFromWetness = -4;
+    int temperatureFromWetness = -5;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
@@ -18,7 +18,7 @@ public class DehydrationConfig implements ConfigData {
      * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
      * quarter of the direct equivalent draining speed.
      */
-    float dehydrationConsumedBySweat = 0.5f / 30f;
+    float dehydrationConsumedBySweat = 1f / 30f;
 
     /**
      * Don't lose water to sweat when below this level.
@@ -27,9 +27,9 @@ public class DehydrationConfig implements ConfigData {
 
     int rehydrationWaterAddedPerLevel = 1;
 
-    int rehydrationDrinkSize = 1000;
+    int rehydrationDrinkSize = 300;
 
-    int temperaturePerWetness = 3;
+    int temperatureFromWetness = -4;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;
@@ -47,7 +47,7 @@ public class DehydrationConfig implements ConfigData {
         return rehydrationDrinkSize;
     }
 
-    public int getTemperaturePerWetness() {
-        return temperaturePerWetness;
+    public int getTemperatureFromWetness() {
+        return temperatureFromWetness;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/DehydrationConfig.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.scorchful.config;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.components.PlayerComponent;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 
@@ -11,43 +12,36 @@ import me.shedaniel.autoconfig.annotation.Config;
 public class DehydrationConfig implements ConfigData {
 
     /**
-     * A direct equivalent would be set this to 8/30:
-     * 4 dehydration points reduces water level by 1, and
-     * water level is out of 20 * 4 = 80, while waterDrunk is out of 300, so 1 water level is 2/30 of waterDrunk
-     * <p>
-     * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
-     * quarter of the direct equivalent draining speed.
-     */
-    float dehydrationConsumedBySweat = 1f / 30f;
-
-    /**
      * Don't lose water to sweat when below this level.
      */
     int minWaterLevelForSweat = 16;
 
-    int rehydrationWaterAddedPerLevel = 1;
+    int maxRehydrationWaterAddedPerLevel = 1;
 
-    int rehydrationDrinkSize = 300;
-
-    int temperatureFromWetness = -5;
-
+    /**
+     * How this value was derived:
+     * <p>
+     * Scorchful only takes 4 points of thirst. 4 points of dehydration per thirst so 4 * 4 = 16 dehydration points.
+     * <p>
+     * There are 300 body water points in Scorchful.
+     * <p>
+     * 16 dehydration points = 300 body water points. So the conversion factor is 16 dp / 300 bw.
+     */
     public float getDehydrationConsumedBySweat() {
-        return dehydrationConsumedBySweat;
+        // adapt based on size of bar
+        float pointRange = (20f - minWaterLevelForSweat) * 4f;
+        return pointRange / PlayerComponent.MAX_WATER;
     }
 
     public int getMinWaterLevelForSweat() {
         return minWaterLevelForSweat;
     }
 
-    public int getRehydrationWaterAddedPerLevel() {
-        return rehydrationWaterAddedPerLevel;
+    public int getMaxRehydrationWaterAddedPerLevel() {
+        return maxRehydrationWaterAddedPerLevel;
     }
 
     public int getRehydrationDrinkSize() {
-        return rehydrationDrinkSize;
-    }
-
-    public int getTemperatureFromWetness() {
-        return temperatureFromWetness;
+        return PlayerComponent.MAX_WATER;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
@@ -3,6 +3,7 @@ package com.github.thedeathlycow.scorchful.config;
 import com.github.thedeathlycow.scorchful.Scorchful;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 @Config(name = Scorchful.MODID + ".modIntegrationConfig")
 public class ModIntegrationConfig implements ConfigData {
@@ -17,6 +18,7 @@ public class ModIntegrationConfig implements ConfigData {
      * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
      * quarter of the direct equivalent draining speed.
      */
+    @ConfigEntry.Gui.Tooltip
     float dehydrationConsumedBySweat = 1f / 30f;
 
     /**
@@ -24,7 +26,14 @@ public class ModIntegrationConfig implements ConfigData {
      * <p>
      * Don't lose water to sweat when below this level.
      */
+    @ConfigEntry.Gui.Tooltip
     int minWaterLevelForSweat = 17;
+
+    /**
+     * Requires Dehydration
+     */
+    @ConfigEntry.Gui.Tooltip
+    int maxThirstAddedByRehydration = 4;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;
@@ -32,5 +41,9 @@ public class ModIntegrationConfig implements ConfigData {
 
     public int getMinWaterLevelForSweat() {
         return minWaterLevelForSweat;
+    }
+
+    public int getMaxThirstAddedByRehydration() {
+        return maxThirstAddedByRehydration;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
@@ -3,7 +3,6 @@ package com.github.thedeathlycow.scorchful.config;
 import com.github.thedeathlycow.scorchful.Scorchful;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
-import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 @Config(name = Scorchful.MODID + ".modIntegrationConfig")
 public class ModIntegrationConfig implements ConfigData {
@@ -11,9 +10,9 @@ public class ModIntegrationConfig implements ConfigData {
     /**
      * Requires Dehydration
      * <p>
-     * A direct equivalent would be set this to 4/30:
+     * A direct equivalent would be set this to 8/30:
      * 4 dehydration points reduces water level by 1, and
-     * water level is out of 20, while waterDrunk is out of 600, so 1 water level is 1/30 of waterDrunk
+     * water level is out of 20 * 4 = 80, while waterDrunk is out of 300, so 1 water level is 2/30 of waterDrunk
      * <p>
      * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
      * quarter of the direct equivalent draining speed.
@@ -25,12 +24,17 @@ public class ModIntegrationConfig implements ConfigData {
      * <p>
      * Don't lose water to sweat when below this level.
      */
-    int minWaterLevelForSweat = 17;
+    int minWaterLevelForSweat = 16;
 
     /**
      * Requires Dehydration
      */
     int maxThirstAddedByRehydration = 4;
+
+    /**
+     * Requires Dehydration
+     */
+    int minWaterLevelToRehydrate = 10;
 
     public float getDehydrationConsumedBySweat() {
         return dehydrationConsumedBySweat;
@@ -42,5 +46,9 @@ public class ModIntegrationConfig implements ConfigData {
 
     public int getMaxThirstAddedByRehydration() {
         return maxThirstAddedByRehydration;
+    }
+
+    public int getMinWaterLevelToRehydrate() {
+        return minWaterLevelToRehydrate;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
@@ -1,0 +1,15 @@
+package com.github.thedeathlycow.scorchful.config;
+
+import com.github.thedeathlycow.scorchful.Scorchful;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
+
+@Config(name = Scorchful.MODID + ".integrationConfig")
+public class ModIntegrationConfig extends PartitioningSerializer.GlobalData {
+
+    @ConfigEntry.Gui.CollapsibleObject
+    @ConfigEntry.Gui.Tooltip
+    public DehydrationConfig dehydrationConfig = new DehydrationConfig();
+
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ModIntegrationConfig.java
@@ -18,7 +18,6 @@ public class ModIntegrationConfig implements ConfigData {
      * However, due to increased effects of water provided by Dehydration - this drains too fast. So, it is set to a
      * quarter of the direct equivalent draining speed.
      */
-    @ConfigEntry.Gui.Tooltip
     float dehydrationConsumedBySweat = 1f / 30f;
 
     /**
@@ -26,13 +25,11 @@ public class ModIntegrationConfig implements ConfigData {
      * <p>
      * Don't lose water to sweat when below this level.
      */
-    @ConfigEntry.Gui.Tooltip
     int minWaterLevelForSweat = 17;
 
     /**
      * Requires Dehydration
      */
-    @ConfigEntry.Gui.Tooltip
     int maxThirstAddedByRehydration = 4;
 
     public float getDehydrationConsumedBySweat() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
@@ -22,6 +22,9 @@ public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
     public ThirstConfig thirstConfig = new ThirstConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
+    public CombatConfig combatConfig = new CombatConfig();
+
+    @ConfigEntry.Gui.CollapsibleObject
     public WeatherConfig weatherConfig = new WeatherConfig();
 
     @ConfigEntry.Gui.CollapsibleObject

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
@@ -42,4 +42,10 @@ public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
                     "You may disable these updates if you don't want this to happen.");
         }
     }
+
+    public int getRehydrationDrinkSize(boolean dehydrationLoaded) {
+        return dehydrationLoaded
+                ? this.integrationConfig.dehydrationConfig.getRehydrationDrinkSize()
+                : this.thirstConfig.getRehydrationDrinkSize();
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
@@ -28,8 +28,7 @@ public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
     public ThirstConfig thirstConfig = new ThirstConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
-    @ConfigEntry.Gui.Tooltip
-    public DehydrationConfig dehydrationConfig = new DehydrationConfig();
+    public ModIntegrationConfig integrationConfig = new ModIntegrationConfig();
 
     public static void updateConfig(ConfigHolder<ScorchfulConfig> configHolder) {
         UpdateConfig config = configHolder.getConfig().updateConfig;

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ScorchfulConfig.java
@@ -19,16 +19,17 @@ public class ScorchfulConfig extends PartitioningSerializer.GlobalData {
     public HeatingConfig heatingConfig = new HeatingConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
-    public ThirstConfig thirstConfig = new ThirstConfig();
-
-    @ConfigEntry.Gui.CollapsibleObject
     public CombatConfig combatConfig = new CombatConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
     public WeatherConfig weatherConfig = new WeatherConfig();
 
     @ConfigEntry.Gui.CollapsibleObject
-    public ModIntegrationConfig integrationConfig = new ModIntegrationConfig();
+    public ThirstConfig thirstConfig = new ThirstConfig();
+
+    @ConfigEntry.Gui.CollapsibleObject
+    @ConfigEntry.Gui.Tooltip
+    public DehydrationConfig dehydrationConfig = new DehydrationConfig();
 
     public static void updateConfig(ConfigHolder<ScorchfulConfig> configHolder) {
         UpdateConfig config = configHolder.getConfig().updateConfig;

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -15,7 +15,7 @@ public class ThirstConfig implements ConfigData {
 
     int waterFromHydratingFood = 300;
 
-    int rehydrationDrinkSize = 300;
+    int rehydrationDrinkSize = 120;
 
     int soakingFromSplashPotions = 300;
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -15,6 +15,8 @@ public class ThirstConfig implements ConfigData {
 
     int waterFromHydratingFood = 300;
 
+    int waterFromParchingFood = -120;
+
     int rehydrationDrinkSize = 120;
 
     int soakingFromSplashPotions = 300;
@@ -43,6 +45,10 @@ public class ThirstConfig implements ConfigData {
 
     public int getWaterFromHydratingFood() {
         return waterFromHydratingFood;
+    }
+
+    public int getWaterFromParchingFood() {
+        return waterFromParchingFood;
     }
 
     public int getRehydrationDrinkSize() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
@@ -1,19 +1,24 @@
 package com.github.thedeathlycow.scorchful.item;
 
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.AbstractFireballEntity;
+import net.minecraft.entity.projectile.SmallFireballEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldEvents;
 
 public class FireChargeThrower implements UseItemCallback {
 
+    private static final int FIRE_CHARGE_COOL_DOWN = 20;
+
     @Override
     public TypedActionResult<ItemStack> interact(PlayerEntity player, World world, Hand hand) {
-        if (player.isSpectator() || world.isClient) {
+        if (player.isSpectator()) {
             return TypedActionResult.pass(ItemStack.EMPTY);
         }
 
@@ -21,25 +26,29 @@ public class FireChargeThrower implements UseItemCallback {
         if (!stack.isOf(Items.FIRE_CHARGE)) {
             return TypedActionResult.pass(ItemStack.EMPTY);
         }
-
-        // spawn fire charge entity
-        var fireball = EntityType.SMALL_FIREBALL.create(world);
-
-        if (fireball == null) {
+        if (player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
             return TypedActionResult.fail(stack);
         }
 
-        fireball.setPosition(player.getX(), player.getBodyY(0.5) + 0.5, player.getZ());
-
-        if (!world.spawnEntity(fireball)) {
-            return TypedActionResult.fail(stack);
+        // spawn fire charge entity
+        if (!world.isClient) {
+            Vec3d rotation = player.getRotationVector();
+            AbstractFireballEntity fireball = new SmallFireballEntity(
+                    world,
+                    player,
+                    rotation.x, rotation.y, rotation.z
+            );
+            fireball.setPosition(fireball.getX(), player.getBodyY(0.5) + 0.5, fireball.getZ());
+            fireball.setItem(stack);
+            world.spawnEntity(fireball);
+            world.syncWorldEvent(null, WorldEvents.BLAZE_SHOOTS, player.getBlockPos(), 0);
         }
 
         // decrement stack
         if (!player.isCreative()) {
             stack.decrement(1);
         }
-        player.getItemCooldownManager().set(stack.getItem(), 20);
+        player.getItemCooldownManager().set(stack.getItem(), FIRE_CHARGE_COOL_DOWN);
 
         return TypedActionResult.success(stack);
     }

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
@@ -1,0 +1,47 @@
+package com.github.thedeathlycow.scorchful.item;
+
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.world.World;
+
+public class FireChargeThrower implements UseItemCallback {
+
+    @Override
+    public TypedActionResult<ItemStack> interact(PlayerEntity player, World world, Hand hand) {
+        if (player.isSpectator() || world.isClient) {
+            return TypedActionResult.pass(ItemStack.EMPTY);
+        }
+
+        ItemStack stack = player.getStackInHand(hand);
+        if (!stack.isOf(Items.FIRE_CHARGE)) {
+            return TypedActionResult.pass(ItemStack.EMPTY);
+        }
+
+        // spawn fire charge entity
+        var fireball = EntityType.SMALL_FIREBALL.create(world);
+
+        if (fireball == null) {
+            return TypedActionResult.fail(stack);
+        }
+
+        fireball.setPosition(player.getX(), player.getBodyY(0.5) + 0.5, player.getZ());
+
+        if (!world.spawnEntity(fireball)) {
+            return TypedActionResult.fail(stack);
+        }
+
+        // decrement stack
+        if (!player.isCreative()) {
+            stack.decrement(1);
+        }
+        player.getItemCooldownManager().set(stack.getItem(), 20);
+
+        return TypedActionResult.success(stack);
+    }
+
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/FireChargeThrower.java
@@ -1,8 +1,11 @@
 package com.github.thedeathlycow.scorchful.item;
 
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.AbstractFireballEntity;
+import net.minecraft.entity.projectile.FireballEntity;
 import net.minecraft.entity.projectile.SmallFireballEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -11,6 +14,8 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldEvents;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FireChargeThrower implements UseItemCallback {
 
@@ -22,8 +27,11 @@ public class FireChargeThrower implements UseItemCallback {
             return TypedActionResult.pass(ItemStack.EMPTY);
         }
 
+        ScorchfulConfig config = Scorchful.getConfig();
+        FireballFactory throwingTypes = config.combatConfig.getFireBallThrownType();
+
         ItemStack stack = player.getStackInHand(hand);
-        if (!stack.isOf(Items.FIRE_CHARGE)) {
+        if (!stack.isOf(Items.FIRE_CHARGE) || throwingTypes == FireballFactory.DISABLED) {
             return TypedActionResult.pass(ItemStack.EMPTY);
         }
         if (player.getItemCooldownManager().isCoolingDown(stack.getItem())) {
@@ -33,11 +41,12 @@ public class FireChargeThrower implements UseItemCallback {
         // spawn fire charge entity
         if (!world.isClient) {
             Vec3d rotation = player.getRotationVector();
-            AbstractFireballEntity fireball = new SmallFireballEntity(
-                    world,
-                    player,
-                    rotation.x, rotation.y, rotation.z
-            );
+            AbstractFireballEntity fireball = throwingTypes.create(world, player, rotation);
+
+            if (fireball == null) {
+                return TypedActionResult.pass(ItemStack.EMPTY);
+            }
+
             fireball.setPosition(fireball.getX(), player.getBodyY(0.5) + 0.5, fireball.getZ());
             fireball.setItem(stack);
             world.spawnEntity(fireball);
@@ -51,6 +60,41 @@ public class FireChargeThrower implements UseItemCallback {
         player.getItemCooldownManager().set(stack.getItem(), FIRE_CHARGE_COOL_DOWN);
 
         return TypedActionResult.success(stack);
+    }
+
+    public enum FireballFactory {
+
+        DISABLED {
+            @Override
+            @Nullable
+            public AbstractFireballEntity create(World world, PlayerEntity player, Vec3d velocity) {
+                return null;
+            }
+        },
+        SMALL {
+            @Override
+            @NotNull
+            public AbstractFireballEntity create(World world, PlayerEntity player, Vec3d velocity) {
+                return new SmallFireballEntity(
+                        world, player,
+                        velocity.x, velocity.y, velocity.z
+                );
+            }
+        },
+        LARGE {
+            @Override
+            @NotNull
+            public AbstractFireballEntity create(World world, PlayerEntity player, Vec3d velocity) {
+                return new FireballEntity(
+                        world, player,
+                        velocity.x, velocity.y, velocity.z, 1
+                );
+            }
+        };
+
+        @Nullable
+        public abstract AbstractFireballEntity create(World world, PlayerEntity player, Vec3d velocity);
+
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
@@ -44,6 +44,11 @@ public class QuenchingFoods {
     }
 
     public enum QuenchingLevel {
+        PARCHING(
+                SItemTags.IS_PARCHING,
+                Text.translatable("item.scorchful.tooltip.parching").setStyle(WaterSkinItem.PARCHING_STYLE),
+                ThirstConfig::getWaterFromParchingFood
+        ),
         REFRESHING(
                 SItemTags.IS_REFRESHING,
                 Text.translatable("item.scorchful.tooltip.refreshing").setStyle(WaterSkinItem.TOOLTIP_STYLE),

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/QuenchingFoods.java
@@ -22,7 +22,7 @@ public class QuenchingFoods {
     }
 
     public static void appendTooltip(ItemStack stack, List<Text> tooltip, @Nullable QuenchingLevel level) {
-        if (level != null && !ScorchfulIntegrations.isThirstModLoaded()) {
+        if (level != null && !ScorchfulIntegrations.isDehydrationLoaded()) {
             tooltip.add(level.tooltipText);
         }
     }
@@ -33,7 +33,7 @@ public class QuenchingFoods {
 
     public static void onConsume(LivingEntity user, ItemStack stack, @Nullable QuenchingLevel level) {
 
-        if (ScorchfulIntegrations.isThirstModLoaded()) {
+        if (ScorchfulIntegrations.isDehydrationLoaded()) {
             return;
         }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/WaterSkinItem.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/WaterSkinItem.java
@@ -42,6 +42,9 @@ public class WaterSkinItem extends DrinkItem {
     public static final Style TOOLTIP_STYLE = Style.EMPTY
             .withColor(TextColor.parse("aqua"));
 
+    public static final Style PARCHING_STYLE = Style.EMPTY
+            .withColor(TextColor.parse("red"));
+
     public static final int MAX_DRINKS = 16;
     private static final String DRINK_NBT_KEY = "drinks";
     private static final String COUNT_NBT_KEY = "count";

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SItemTags.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SItemTags.java
@@ -13,6 +13,8 @@ public class SItemTags {
 
     public static final TagKey<Item> IS_HYDRATING = of("is_hydrating");
 
+    public static final TagKey<Item> IS_PARCHING = of("is_parching");
+
     public static final TagKey<Item> HEAT_NEUTRAL = of("heat_resistance/neutral");
 
     public static final TagKey<Item> HEAT_PROTECTIVE = of("heat_resistance/protective");

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/ThirstCommand.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/ThirstCommand.java
@@ -2,6 +2,7 @@ package com.github.thedeathlycow.scorchful.server;
 
 import com.github.thedeathlycow.scorchful.components.ScorchfulComponents;
 import com.mojang.brigadier.CommandDispatcher;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.command.ServerCommandSource;
@@ -12,6 +13,10 @@ import static net.minecraft.server.command.CommandManager.literal;
 public class ThirstCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+
+        if (!FabricLoader.getInstance().isDevelopmentEnvironment()) {
+            return;
+        }
 
         var thirst =
                 argument("target", EntityArgumentType.player())

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/AmbientTemperatureController.java
@@ -23,10 +23,6 @@ import net.minecraft.world.dimension.DimensionType;
 
 public class AmbientTemperatureController extends EnvironmentControllerDecorator {
 
-    private static final int SKY_LIGHT_BELOW_FOR_SHADE = 2;
-
-    private static final int SHADE_COOLING = 1;
-
 
     /**
      * Constructs a decorator out of a base controller
@@ -156,8 +152,6 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
                 if (isScorching(biome, season)) {
                     warmth += config.heatingConfig.getScorchingBiomeHeatIncrease();
                 }
-            } else if (skylight <= minLevel - SKY_LIGHT_BELOW_FOR_SHADE) {
-                warmth -= SHADE_COOLING;
             }
         }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -15,10 +15,7 @@ public class Cooling {
         if (entity.thermoo$getTemperature() > 0 && entity.thermoo$isWet()) {
             ScorchfulConfig config = Scorchful.getConfig();
 
-            int temperatureChange = ScorchfulIntegrations.isDehydrationLoaded()
-                    ? config.integrationConfig.dehydrationConfig.getTemperatureFromWetness()
-                    : config.thirstConfig.getTemperatureFromWetness();
-
+            int temperatureChange = config.thirstConfig.getTemperatureFromWetness();
             World world = entity.getWorld();
             if (world.getBiome(entity.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
                 float efficiency = config.thirstConfig.getHumidBiomeSweatEfficiency();

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -1,8 +1,8 @@
 package com.github.thedeathlycow.scorchful.temperature;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.compat.ScorchfulIntegrations;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
-import com.github.thedeathlycow.scorchful.config.ThirstConfig;
 import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
 import com.github.thedeathlycow.thermoo.api.temperature.HeatingModes;
 import net.minecraft.entity.LivingEntity;
@@ -13,12 +13,16 @@ public class Cooling {
 
     public static void tick(LivingEntity entity) {
         if (entity.thermoo$getTemperature() > 0 && entity.thermoo$isWet()) {
-            ThirstConfig config = Scorchful.getConfig().thirstConfig;
+            ScorchfulConfig config = Scorchful.getConfig();
 
-            int temperatureChange = config.getTemperatureFromWetness();
+            int temperatureChange = ScorchfulIntegrations.isDehydrationLoaded()
+                    ? config.integrationConfig.dehydrationConfig.getTemperatureFromWetness()
+                    : config.thirstConfig.getTemperatureFromWetness();
+
             World world = entity.getWorld();
             if (world.getBiome(entity.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
-                temperatureChange = MathHelper.floor(temperatureChange * config.getHumidBiomeSweatEfficiency());
+                float efficiency = config.thirstConfig.getHumidBiomeSweatEfficiency();
+                temperatureChange = MathHelper.floor(temperatureChange * efficiency);
             }
 
             entity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -4,6 +4,7 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import com.github.thedeathlycow.scorchful.config.ThirstConfig;
 import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
+import com.github.thedeathlycow.thermoo.api.temperature.HeatingModes;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -20,7 +21,7 @@ public class Cooling {
                 temperatureChange = MathHelper.floor(temperatureChange * config.getHumidBiomeSweatEfficiency());
             }
 
-            entity.thermoo$addTemperature(temperatureChange);
+            entity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);
         }
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -1,13 +1,17 @@
 package com.github.thedeathlycow.scorchful.temperature;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.compat.ScorchfulIntegrations;
+import com.github.thedeathlycow.scorchful.components.PlayerComponent;
 import com.github.thedeathlycow.scorchful.components.ScorchfulComponents;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
+import com.github.thedeathlycow.scorchful.enchantment.SEnchantmentHelper;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
 import com.github.thedeathlycow.thermoo.api.temperature.Soakable;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.world.LightType;
 
@@ -25,13 +29,29 @@ public class WetTickController extends EnvironmentControllerDecorator {
         }
 
         ScorchfulConfig config = Scorchful.getConfig();
-        int soakChange = this.getWetChange(entity, config);
-        soakChange = this.getDryChange(entity, config, soakChange);
+        int soakChange = getWetChange(entity, config);
+        soakChange = getDryChange(entity, config, soakChange);
 
         return soakChange;
     }
 
-    private int getDryChange(LivingEntity entity, ScorchfulConfig config, int wetChange) {
+    private static int getWetChange(LivingEntity entity, ScorchfulConfig config) {
+        int soakChange = 0;
+
+        // immediately soak players in water
+        if (entity.isSubmergedIn(FluidTags.WATER)) {
+            return entity.thermoo$getMaxWetTicks();
+        }
+
+        // add wetness when touching, but not submerged in, water or rain
+        if (entity.isTouchingWaterOrRain() || entity.getBlockStateAtPos().isOf(Blocks.WATER_CAULDRON)) {
+            soakChange += config.thirstConfig.getTouchingWaterWetnessIncrease();
+        }
+
+        return soakChange;
+    }
+
+    private static int getDryChange(LivingEntity entity, ScorchfulConfig config, int wetChange) {
         // dry off slowly when not being wetted
         if (wetChange <= 0 && entity.thermoo$isWet()) {
             wetChange = -config.thirstConfig.getDryRate();
@@ -47,27 +67,25 @@ public class WetTickController extends EnvironmentControllerDecorator {
             wetChange -= config.thirstConfig.getOnFireDryDate();
         }
 
-        if (wetChange < 0 && entity.isPlayer() && entity.thermoo$isWet() && entity.getRandom().nextBoolean()) {
-            ScorchfulComponents.PLAYER.get(entity).tickRehydration(config);
+        if (entity.isPlayer()) {
+            tickRehydration((PlayerEntity) entity, config, wetChange);
         }
 
         return wetChange;
     }
 
-    private int getWetChange(LivingEntity entity, ScorchfulConfig config) {
-        int soakChange = 0;
-
-        // immediately soak players in water
-        if (entity.isSubmergedIn(FluidTags.WATER)) {
-            return entity.thermoo$getMaxWetTicks();
+    private static void tickRehydration(PlayerEntity player, ScorchfulConfig config, int wetChange) {
+        int rehydrationLevel = SEnchantmentHelper.getTotalRehydrationForPlayer(player);
+        PlayerComponent component = ScorchfulComponents.PLAYER.get(player);
+        if (rehydrationLevel > 0) {
+            boolean dehydrationLoaded = ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.DEHYDRATION_ID);
+            if (wetChange < 0 && player.getRandom().nextBoolean()) {
+                component.tickRehydrationWaterRecapture(config, dehydrationLoaded);
+            }
+            component.tickRehydration(config, rehydrationLevel, dehydrationLoaded);
+        } else {
+            component.resetRehydration();
         }
-
-        // add wetness when touching, but not submerged in, water or rain
-        if (entity.isTouchingWaterOrRain() || entity.getBlockStateAtPos().isOf(Blocks.WATER_CAULDRON)) {
-            soakChange += config.thirstConfig.getTouchingWaterWetnessIncrease();
-        }
-
-        return soakChange;
     }
 
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -78,7 +78,7 @@ public class WetTickController extends EnvironmentControllerDecorator {
         int rehydrationLevel = SEnchantmentHelper.getTotalRehydrationForPlayer(player);
         PlayerComponent component = ScorchfulComponents.PLAYER.get(player);
         if (rehydrationLevel > 0) {
-            boolean dehydrationLoaded = ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.DEHYDRATION_ID);
+            boolean dehydrationLoaded = ScorchfulIntegrations.isDehydrationLoaded();
             if (wetChange < 0 && player.getRandom().nextBoolean()) {
                 component.tickRehydrationWaterRecapture(config, dehydrationLoaded);
             }

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/WetTickController.java
@@ -47,8 +47,8 @@ public class WetTickController extends EnvironmentControllerDecorator {
             wetChange -= config.thirstConfig.getOnFireDryDate();
         }
 
-        if (wetChange < 0 && entity.isPlayer() && entity.thermoo$isWet()) {
-            ScorchfulComponents.PLAYER.get(entity).tickRehydration(config.thirstConfig);
+        if (wetChange < 0 && entity.isPlayer() && entity.thermoo$isWet() && entity.getRandom().nextBoolean()) {
+            ScorchfulComponents.PLAYER.get(entity).tickRehydration(config);
         }
 
         return wetChange;

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -120,7 +120,7 @@
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating",
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationWaterAddedPerLevel": "Water added per level of Rehydration",
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationDrinkSize": "Rehydration drink size override",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.temperaturePerWetness": "Temperature from Wetness override",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.temperatureFromWetness": "Temperature from Wetness override",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -104,6 +104,9 @@
     "text.autoconfig.scorchful.option.thirstConfig.humidBiomeSweatEfficiency": "Humid biome sweating efficiency",
     "text.autoconfig.scorchful.option.thirstConfig.maxRehydrationEfficiency": "Maximum Rehydration Enchantment efficiency",
     
+    "text.autoconfig.scorchful.option.combatConfig": "Combat Config",
+    "text.autoconfig.scorchful.option.combatConfig.fireBallThrownType": "Fire Charge thrown type",
+    
     "text.autoconfig.scorchful.option.weatherConfig": "Weather Config",
     "text.autoconfig.scorchful.option.weatherConfig.doSandPileAccumulation": "Do Sand Pile accumulation",
     "text.autoconfig.scorchful.option.weatherConfig.sandPileAccumulationHeight": "Sand Pile accumulation height",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -112,11 +112,11 @@
     "text.autoconfig.scorchful.option.weatherConfig.sandPileAccumulationHeight": "Sand Pile accumulation height",
     "text.autoconfig.scorchful.option.weatherConfig.sandstormSlownessAmountPercent": "Sandstorm Slowness amount (percent from -1 to +1)",
     
-    "text.autoconfig.scorchful.option.integrationConfig": "Mod Integrations Config",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick (requires Dehydration)",
-    "text.autoconfig.scorchful.option.integrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating (requires Dehydration)",
-    "text.autoconfig.scorchful.option.integrationConfig.maxThirstAddedByRehydration": "Maximum thirst added by Rehydration (requires Dehydration)",
-    "text.autoconfig.scorchful.option.integrationConfig.minWaterLevelToRehydrate": "Minimum water level to rehydrate (requires Dehydration)",
+    "text.autoconfig.scorchful.option.dehydrationConfig": "Dehydration Config",
+    "text.autoconfig.scorchful.option.dehydrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick (requires Dehydration)",
+    "text.autoconfig.scorchful.option.dehydrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating (requires Dehydration)",
+    "text.autoconfig.scorchful.option.dehydrationConfig.rehydrationWaterAddedPerLevel": "Water added per level of Rehydration (requires Dehydration)",
+    "text.autoconfig.scorchful.option.dehydrationConfig.minWaterLevelToRehydrate": "Minimum water level to rehydrate (requires Dehydration)",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -115,6 +115,7 @@
     "text.autoconfig.scorchful.option.integrationConfig": "Mod Integrations Config",
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick (requires Dehydration)",
     "text.autoconfig.scorchful.option.integrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating (requires Dehydration)",
+    "text.autoconfig.scorchful.option.integrationConfig.maxThirstAddedByRehydration": "Maximum thirst added by Rehydration (requires Dehydration)",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -112,11 +112,15 @@
     "text.autoconfig.scorchful.option.weatherConfig.sandPileAccumulationHeight": "Sand Pile accumulation height",
     "text.autoconfig.scorchful.option.weatherConfig.sandstormSlownessAmountPercent": "Sandstorm Slowness amount (percent from -1 to +1)",
     
-    "text.autoconfig.scorchful.option.dehydrationConfig": "Dehydration Config",
-    "text.autoconfig.scorchful.option.dehydrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick (requires Dehydration)",
-    "text.autoconfig.scorchful.option.dehydrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating (requires Dehydration)",
-    "text.autoconfig.scorchful.option.dehydrationConfig.rehydrationWaterAddedPerLevel": "Water added per level of Rehydration (requires Dehydration)",
-    "text.autoconfig.scorchful.option.dehydrationConfig.minWaterLevelToRehydrate": "Minimum water level to rehydrate (requires Dehydration)",
+    "text.autoconfig.scorchful.option.integrationConfig": "Mod Integration Config",
+    
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig": "Dehydration Config",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.@Tooltip": "Requires Dehydration to have any effect",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationWaterAddedPerLevel": "Water added per level of Rehydration",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationDrinkSize": "Rehydration drink size override",
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.temperaturePerWetness": "Temperature from Wetness override",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -116,6 +116,7 @@
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick (requires Dehydration)",
     "text.autoconfig.scorchful.option.integrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating (requires Dehydration)",
     "text.autoconfig.scorchful.option.integrationConfig.maxThirstAddedByRehydration": "Maximum thirst added by Rehydration (requires Dehydration)",
+    "text.autoconfig.scorchful.option.integrationConfig.minWaterLevelToRehydrate": "Minimum water level to rehydrate (requires Dehydration)",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -19,6 +19,7 @@
     "item.scorchful.tooltip.refreshing": "Refreshing \uD83C\uDF0A",
     "item.scorchful.tooltip.sustaining": "Sustaining \uD83C\uDF0A\uD83C\uDF0A",
     "item.scorchful.tooltip.hydrating": "Hydrating \uD83C\uDF0A\uD83C\uDF0A\uD83C\uDF0A",
+    "item.scorchful.tooltip.parching": "Parching ☀",
     
     
     "block.scorchful.crimson_lily": "Crimson Lily",
@@ -96,6 +97,7 @@
     "text.autoconfig.scorchful.option.thirstConfig.waterFromRefreshingFood": "Water from Refreshing food",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromSustainingFood": "Water from Sustaining food",
     "text.autoconfig.scorchful.option.thirstConfig.waterFromHydratingFood": "Water from Hydrating food",
+    "text.autoconfig.scorchful.option.thirstConfig.waterFromParchingFood": "Water from Parching food",
     "text.autoconfig.scorchful.option.thirstConfig.rehydrationDrinkSize": "Rehydration drink size",
     "text.autoconfig.scorchful.option.thirstConfig.soakingFromSplashPotions": "Soaking from Splash Potions",
     "text.autoconfig.scorchful.option.thirstConfig.touchingWaterWetnessIncrease": "Touching water or rain wetness increase per tick",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -116,12 +116,9 @@
     
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig": "Dehydration Config",
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.@Tooltip": "Requires Dehydration to have any effect",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.dehydrationConsumedBySweat": "Dehydration points consumed by sweat per tick",
     "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.minWaterLevelForSweat": "Minimum water level required for sweating",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationWaterAddedPerLevel": "Water added per level of Rehydration",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.rehydrationDrinkSize": "Rehydration drink size override",
-    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.temperatureFromWetness": "Temperature from Wetness override",
-    
+    "text.autoconfig.scorchful.option.integrationConfig.dehydrationConfig.maxRehydrationWaterAddedPerLevel": "Maximum water added per level of Rehydration",
+
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",
     "text.autoconfig.scorchful.option.updateConfig.enableConfigUpdates": "Enable config auto updates",

--- a/src/main/resources/data/dehydration/hydration_items/scorchful.json
+++ b/src/main/resources/data/dehydration/hydration_items/scorchful.json
@@ -2,7 +2,12 @@
     "2": {
         "replace": false,
         "items": [
-            "scorchful:cactus_juice",
+            "scorchful:cactus_juice"
+        ]
+    },
+    "4": {
+        "replace": false,
+        "items": [
             "scorchful:water_skin"
         ]
     }

--- a/src/main/resources/data/scorchful/tags/items/is_hydrating.json
+++ b/src/main/resources/data/scorchful/tags/items/is_hydrating.json
@@ -27,6 +27,62 @@
         {
             "required": false,
             "id": "farmersdelight:apple_cider"
+        },
+        {
+            "required": false,
+            "id": "#vinery:grapejuice"
+        },
+        {
+            "required": false,
+            "id": "vinery:apple_juice"
+        },
+        {
+            "required": false,
+            "id": "beachparty:refreshing_drink"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:green_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:black_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:hibiscus_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:lavender_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:yerba_mate_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:rooibos_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:oolong_tea"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:armor_flask_big"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:damage_flask_big"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:feral_flask_big"
+        },
+        {
+            "required": false,
+            "id": "#meadow:wooden_milk_bucket"
         }
     ]
 }

--- a/src/main/resources/data/scorchful/tags/items/is_parching.json
+++ b/src/main/resources/data/scorchful/tags/items/is_parching.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:cooked_chicken"
+    ]
+}

--- a/src/main/resources/data/scorchful/tags/items/is_parching.json
+++ b/src/main/resources/data/scorchful/tags/items/is_parching.json
@@ -1,6 +1,77 @@
 {
     "replace": false,
     "values": [
-        "minecraft:cooked_chicken"
+        {
+            "required": false,
+            "id": "#vinery:wine"
+        },
+        {
+            "required": false,
+            "id": "vinery:mead"
+        },
+        {
+            "required": false,
+            "id": "beachparty:honey_cocktail"
+        },
+        {
+            "required": false,
+            "id": "beachparty:melon_cocktail"
+        },
+        {
+            "required": false,
+            "id": "beachparty:pumpkin_cocktail"
+        },
+        {
+            "required": false,
+            "id": "beachparty:cocoa_cocktail"
+        },
+        {
+            "required": false,
+            "id": "beachparty:sweetberries_cocktail"
+        },
+        {
+            "required": false,
+            "id": "beachparty:coconut_cocktail"
+        },
+        {
+            "required": false,
+            "id": "brewery:beer_wheat"
+        },
+        {
+            "required": false,
+            "id": "brewery:beer_barley"
+        },
+        {
+            "required": false,
+            "id": "brewery:beer_hops"
+        },
+        {
+            "required": false,
+            "id": "brewery:beer_haley"
+        },
+        {
+            "required": false,
+            "id": "brewery:whiskey_jojannik"
+        },
+        {
+            "required": false,
+            "id": "brewery:whiskey_lilitusinglemalt"
+        },
+        {
+            "required": false,
+            "id": "brewery:whiskey_cristelwalker"
+        },
+        {
+            "required": false,
+            "id": "brewery:whiskey_maggoallen"
+        },
+        {
+            "required": false,
+            "id": "brewery:whiskey_carrasconlabel"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:coffee"
+        }
     ]
 }

--- a/src/main/resources/data/scorchful/tags/items/is_refreshing.json
+++ b/src/main/resources/data/scorchful/tags/items/is_refreshing.json
@@ -13,6 +13,42 @@
         {
             "required": false,
             "id": "farmersdelight:melon_popsicle"
+        },
+        {
+            "required": false,
+            "id": "vinery:red_grape"
+        },
+        {
+            "required": false,
+            "id": "vinery:white_grape"
+        },
+        {
+            "required": false,
+            "id": "vinery:savanna_grapes_red"
+        },
+        {
+            "required": false,
+            "id": "vinery:savanna_grapes_white"
+        },
+        {
+            "required": false,
+            "id": "vinery:taiga_grapes_red"
+        },
+        {
+            "required": false,
+            "id": "vinery:taiga_grapes_white"
+        },
+        {
+            "required": false,
+            "id": "vinery:jungle_grapes_red"
+        },
+        {
+            "required": false,
+            "id": "vinery:jungle_grapes_white"
+        },
+        {
+            "required": false,
+            "id": "vinery:cherry"
         }
     ]
 }

--- a/src/main/resources/data/scorchful/tags/items/is_refreshing.json
+++ b/src/main/resources/data/scorchful/tags/items/is_refreshing.json
@@ -12,6 +12,10 @@
         "minecraft:glow_berries",
         {
             "required": false,
+            "id": "#c:berries"
+        },
+        {
+            "required": false,
             "id": "farmersdelight:melon_popsicle"
         },
         {
@@ -49,6 +53,54 @@
         {
             "required": false,
             "id": "vinery:cherry"
+        },
+        {
+            "required": false,
+            "id": "bakery:strawberry"
+        },
+        {
+            "required": false,
+            "id": "beachparty:open_coconut"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_melon"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_sweetberries"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_chocolate"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_cactus"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_coconut"
+        },
+        {
+            "required": false,
+            "id": "beachparty:chocolate_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:coconut_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:sweetberry_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:raw_mussel_meat"
+        },
+        {
+            "required": false,
+            "id": "candlelight:tomato"
         }
     ]
 }

--- a/src/main/resources/data/scorchful/tags/items/is_sustaining.json
+++ b/src/main/resources/data/scorchful/tags/items/is_sustaining.json
@@ -41,6 +41,42 @@
         {
             "required": false,
             "id": "farmersdelight:noodle_soup"
+        },
+        {
+            "required": false,
+            "id": "beachparty:chocolate_milkshake"
+        },
+        {
+            "required": false,
+            "id": "beachparty:coconut_milkshake"
+        },
+        {
+            "required": false,
+            "id": "beachparty:sweetberry_milkshake"
+        },
+        {
+            "required": false,
+            "id": "candlelight:tomato_soup"
+        },
+        {
+            "required": false,
+            "id": "candlelight:mushroom_soup"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:milk_coffee"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:armor_flask"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:damage_flask"
+        },
+        {
+            "required": false,
+            "id": "herbalbrews:feral_flask"
         }
     ]
 }


### PR DESCRIPTION
This update reworks how Scorchful interacts with Dehydration (when it is installed) and also takes the first step towards combat.

* Made Fire Charges (the vanilla item) throwable (Closes #41)
* Removed passive shading (fixes #39 - this caused too many issues with Frostiful installed)
* Made Rehydration pop more often (though gives less water)
* Added a new parching foods tag. This is not used by any vanilla items, but is used by alcoholic items from Let's Do mods. More items are likely to be made parching in the future.
* Added integration for the foods and drinks added by various Let's Do mods. Note that most of these items won't have their tooltip working, but that is an issue with how Let's Do implements their tooltips (if they call `super.addHoverText` it will work).

### Dehydration Integration Reworking

Dehydration and Scorchful integration has been updated. The gameplay experience with Dehydration installed should now be identical the experience without it - except of course you *must* manage thirst to avoid death. All of these changes only apply when Dehydration is installed.

Closes #29 

* Dehydration has been given its own config section in the Mod Integration Config. 
* Sweating now drains up to 4 points of thirst (configurable)
* Dehydration added by wetness is now based on the maximum number of points of thirst Scorchful will take, and it is no longer directly configurable.
* These changes should make it so that sweating will last roughly as long with Dehydration as it does without, making future balance changes easier. 
* Fixes #40 - Rehydration does not work with Dehydration
* Rehydration now requires 4 points of thirst to be drained before it can pop
* Rehydration enchantment now provides a random amount of thirst when it pops, increasing with the number of armor pieces enchanted with Rehydration worn. 
