### PR TITLE
Tropical Seasons Humidity Integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ mod_menu_version=11.0.1
 cloth_config_version=15.0.127
 
 # Thermoo
-thermoo_version=4.1
+thermoo_version=4.2
 
 # Ladysnake Mods
 cca_version=6.1.0

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -40,7 +40,7 @@ public class Scorchful implements ModInitializer {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
 
-    public static final int CONFIG_VERSION = 4;
+    public static final int CONFIG_VERSION = 5;
 
     private static ConfigHolder<ScorchfulConfig> configHolder = null;
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/SeasonsConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/SeasonsConfig.java
@@ -9,8 +9,19 @@ public class SeasonsConfig implements ConfigData {
 
     boolean enableSeasonsIntegration = true;
 
+    float wetSeasonHumidBiomeSweatEfficiency = 1f / 6f;
+
+    float drySeasonHumidBiomeSweatEfficiency = 0.5f;
+
     public boolean enableSeasonsIntegration() {
         return enableSeasonsIntegration;
     }
 
+    public float getWetSeasonHumidBiomeSweatEfficiency() {
+        return wetSeasonHumidBiomeSweatEfficiency;
+    }
+
+    public float getDrySeasonHumidBiomeSweatEfficiency() {
+        return drySeasonHumidBiomeSweatEfficiency;
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/ThirstConfig.java
@@ -27,7 +27,7 @@ public class ThirstConfig implements ConfigData {
 
     int onFireDryDate = 3;
 
-    float humidBiomeSweatEfficiency = 1f / 6f;
+    float humidBiomeSweatEfficiency = 1f / 3f;
 
     float maxRehydrationEfficiency = 0.75f;
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/temperature/Cooling.java
@@ -1,29 +1,62 @@
 package com.github.thedeathlycow.scorchful.temperature;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
-import com.github.thedeathlycow.scorchful.compat.ScorchfulIntegrations;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
+import com.github.thedeathlycow.scorchful.config.SeasonsConfig;
 import com.github.thedeathlycow.scorchful.registry.tag.SBiomeTags;
+import com.github.thedeathlycow.thermoo.api.season.ThermooSeason;
 import com.github.thedeathlycow.thermoo.api.temperature.HeatingModes;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
 
 public class Cooling {
 
     public static void tick(LivingEntity entity) {
         if (entity.thermoo$getTemperature() > 0 && entity.thermoo$isWet()) {
-            ScorchfulConfig config = Scorchful.getConfig();
-
-            int temperatureChange = config.thirstConfig.getTemperatureFromWetness();
-            World world = entity.getWorld();
-            if (!entity.isSubmergedInWater() && world.getBiome(entity.getBlockPos()).isIn(SBiomeTags.HUMID_BIOMES)) {
-                float efficiency = config.thirstConfig.getHumidBiomeSweatEfficiency();
-                temperatureChange = MathHelper.floor(temperatureChange * efficiency);
-            }
-
-            entity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);
+            tickWetAndWarm(entity);
         }
+    }
+
+    private static void tickWetAndWarm(LivingEntity entity) {
+        ScorchfulConfig config = Scorchful.getConfig();
+
+        int temperatureChange = config.thirstConfig.getTemperatureFromWetness();
+        World world = entity.getWorld();
+        if (!entity.isSubmergedInWater()) {
+            float efficiency = getSweatEfficiency(world, entity.getBlockPos(), config);
+            temperatureChange = MathHelper.floor(temperatureChange * efficiency);
+        }
+
+        entity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);
+    }
+
+    private static float getSweatEfficiency(World world, BlockPos pos, ScorchfulConfig config) {
+        RegistryEntry<Biome> biome = world.getBiome(pos);
+        if (biome.isIn(SBiomeTags.HUMID_BIOMES)) {
+            return getSeasonalSweatEfficiency(world, pos, config);
+        }
+
+        return 1f;
+    }
+
+    private static float getSeasonalSweatEfficiency(World world, BlockPos pos, ScorchfulConfig config) {
+        float baseEfficiency = config.thirstConfig.getHumidBiomeSweatEfficiency();
+        SeasonsConfig seasonsConfig = config.integrationConfig.seasonsConfig;
+
+        if (!seasonsConfig.enableSeasonsIntegration()) {
+            return baseEfficiency;
+        }
+
+        ThermooSeason season = ThermooSeason.getCurrentTropicalSeason(world, pos).orElse(null);
+        return switch (season) {
+            case TROPICAL_WET -> seasonsConfig.getWetSeasonHumidBiomeSweatEfficiency();
+            case TROPICAL_DRY -> seasonsConfig.getDrySeasonHumidBiomeSweatEfficiency();
+            case null, default -> baseEfficiency;
+        };
     }
 
     private Cooling() {

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -157,6 +157,8 @@
     "text.autoconfig.scorchful.option.integrationConfig.seasonsConfig": "Seasons Config",
     "text.autoconfig.scorchful.option.integrationConfig.seasonsConfig.@Tooltip": "Requires Fabric Seasons or Serene Seasons AND Thermoo Patches",
     "text.autoconfig.scorchful.option.integrationConfig.seasonsConfig.enableSeasonsIntegration": "Enable seasons integration",
+    "text.autoconfig.scorchful.option.integrationConfig.seasonsConfig.wetSeasonHumidBiomeSweatEfficiency": "Wet Season humid biome sweat efficiency",
+    "text.autoconfig.scorchful.option.integrationConfig.seasonsConfig.drySeasonHumidBiomeSweatEfficiency": "Dry Season humid biome sweat efficiency",
     
     "text.autoconfig.scorchful.option.updateConfig": "Update Config",
     "text.autoconfig.scorchful.option.updateConfig.currentConfigVersion": "Current config version",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,7 @@
 		"minecraft": ">=1.21- <1.21.2-",
 		"java": ">=21",
 		"fabric-api": ">=0.100.6",
-		"thermoo": ">=4.1"
+		"thermoo": ">=4.2"
 	},
 	"suggests": {
 		"frostiful": "*",


### PR DESCRIPTION
- The config version is now `5`, this will cause your config to reset if you have not disabled config auto updates! 
- Added dynamic seasonal humidity to humid tropical biomes
- By default, sweat efficiency in humid biomes was increased from 1/6 to 1/3 
- During the Wet Season in humid tropical biomes, sweat efficiency is lowered to 1/6
- During the Dry Season in humid tropical biomes, sweat efficiency is increased to 1/2
- This only affects *tropical* biomes, other humid biomes like Lush and Dripstone Caves are not affected 
- With Serene Seasons, Thermoo Patches only considers it to be the wet/dry season during the mid wet/mid dry season respectively. This is because that is when the effects of those seasons are most apparent. 

PR specific notes: 

Another branch, [tropical seasons integration](/TheDeathlyCow/scorchful/tree/dev/tropical-seasons-integration),tried another approach of expanding and contracting which biomes are considered 'humid' based on the season, similar to how temperature integrates with seasons. However, this approach was determined to not be very useful or intuitive. This approach of changing the humidity based on the season will be used instead. 
