### PR TITLE
Add Turtle Scutes to Oceanic Chests 

### DIFF
--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -8,6 +8,7 @@ import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
 import com.github.thedeathlycow.scorchful.item.FireChargeThrower;
 import com.github.thedeathlycow.scorchful.item.HeatResistanceHelper;
 import com.github.thedeathlycow.scorchful.item.component.DrinkLevelComponent;
+import com.github.thedeathlycow.scorchful.item.loot.TurtleScuteLootTableModifier;
 import com.github.thedeathlycow.scorchful.registry.*;
 import com.github.thedeathlycow.scorchful.server.ThirstCommand;
 import com.github.thedeathlycow.scorchful.server.network.TemperatureSoundEventPacket;
@@ -25,6 +26,7 @@ import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.damage.DamageTypes;
@@ -96,6 +98,7 @@ public class Scorchful implements ModInitializer {
         );
 
         this.registerThermooEventListeners();
+        LootTableEvents.MODIFY.register(new TurtleScuteLootTableModifier());
 
         PayloadTypeRegistry.playS2C().register(TemperatureSoundEventPacket.PACKET_ID, TemperatureSoundEventPacket.PACKET_CODEC);
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/loot/TurtleScuteLootTableModifier.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/loot/TurtleScuteLootTableModifier.java
@@ -1,0 +1,43 @@
+package com.github.thedeathlycow.scorchful.item.loot;
+
+
+import com.github.thedeathlycow.scorchful.Scorchful;
+import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
+import net.fabricmc.fabric.api.loot.v3.LootTableSource;
+import net.minecraft.item.Items;
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.LootTables;
+import net.minecraft.loot.entry.ItemEntry;
+import net.minecraft.loot.entry.LootTableEntry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.util.Identifier;
+
+public class TurtleScuteLootTableModifier implements LootTableEvents.Modify {
+
+    public static final RegistryKey<LootTable> EXTRA_TURTLE_SCUTE_CHEST = RegistryKey.of(
+            RegistryKeys.LOOT_TABLE,
+            Scorchful.id("chests/extra_turtle_scute")
+    );
+
+
+
+    @Override
+    public void modifyLootTable(
+            RegistryKey<LootTable> key,
+            LootTable.Builder tableBuilder,
+            LootTableSource source,
+            RegistryWrapper.WrapperLookup registries
+    ) {
+        if (key == LootTables.BURIED_TREASURE_CHEST && source.isBuiltin()) {
+            LootPool.Builder pool = LootPool.builder()
+                    .with(LootTableEntry.builder(EXTRA_TURTLE_SCUTE_CHEST));
+
+            tableBuilder.pool(pool);
+        }
+
+
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/loot/TurtleScuteLootTableModifier.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/loot/TurtleScuteLootTableModifier.java
@@ -4,24 +4,19 @@ package com.github.thedeathlycow.scorchful.item.loot;
 import com.github.thedeathlycow.scorchful.Scorchful;
 import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
 import net.fabricmc.fabric.api.loot.v3.LootTableSource;
-import net.minecraft.item.Items;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTables;
-import net.minecraft.loot.entry.ItemEntry;
 import net.minecraft.loot.entry.LootTableEntry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.util.Identifier;
 
 public class TurtleScuteLootTableModifier implements LootTableEvents.Modify {
 
-    public static final RegistryKey<LootTable> EXTRA_TURTLE_SCUTE_CHEST = RegistryKey.of(
-            RegistryKeys.LOOT_TABLE,
-            Scorchful.id("chests/extra_turtle_scute")
-    );
-
+    public static final RegistryKey<LootTable> EXTRA_SCUTE_IN_BURIED_TREASURE = registryKey("chests/extra_turtle_scute/buried_treasure");
+    public static final RegistryKey<LootTable> EXTRA_SCUTE_IN_SHIPWRECK_SUPPLY = registryKey("chests/extra_turtle_scute/shipwreck_supply");
+    public static final RegistryKey<LootTable> EXTRA_SCUTE_IN_SHIPWRECK_TREASURE = registryKey("chests/extra_turtle_scute/shipwreck_treasure");
 
 
     @Override
@@ -31,13 +26,34 @@ public class TurtleScuteLootTableModifier implements LootTableEvents.Modify {
             LootTableSource source,
             RegistryWrapper.WrapperLookup registries
     ) {
-        if (key == LootTables.BURIED_TREASURE_CHEST && source.isBuiltin()) {
-            LootPool.Builder pool = LootPool.builder()
-                    .with(LootTableEntry.builder(EXTRA_TURTLE_SCUTE_CHEST));
+        if (!source.isBuiltin()) {
+            return;
+        }
 
+        // could be better with a map implementation, but unnecessary here imo
+        LootPool.Builder pool = null;
+
+        if (key == LootTables.BURIED_TREASURE_CHEST) {
+            pool = LootPool.builder()
+                    .with(LootTableEntry.builder(EXTRA_SCUTE_IN_BURIED_TREASURE));
+        } else if (key == LootTables.SHIPWRECK_SUPPLY_CHEST) {
+            pool = LootPool.builder()
+                    .with(LootTableEntry.builder(EXTRA_SCUTE_IN_SHIPWRECK_SUPPLY));
+        } else if (key == LootTables.SHIPWRECK_TREASURE_CHEST) {
+            pool = LootPool.builder()
+                    .with(LootTableEntry.builder(EXTRA_SCUTE_IN_SHIPWRECK_TREASURE));
+        }
+
+        if (pool != null) {
             tableBuilder.pool(pool);
         }
 
+    }
 
+    private static RegistryKey<LootTable> registryKey(String name) {
+        return RegistryKey.of(
+                RegistryKeys.LOOT_TABLE,
+                Scorchful.id(name)
+        );
     }
 }

--- a/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute.json
+++ b/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute.json
@@ -1,0 +1,22 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:turtle_scute",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 8
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/buried_treasure.json
+++ b/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/buried_treasure.json
@@ -10,7 +10,7 @@
                         {
                             "function": "minecraft:set_count",
                             "count": {
-                                "min": 1,
+                                "min": 2,
                                 "max": 8
                             }
                         }

--- a/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/shipwreck_supply.json
+++ b/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/shipwreck_supply.json
@@ -1,0 +1,19 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:turtle_scute"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:random_chance",
+                    "chance": 0.25
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/shipwreck_treasure.json
+++ b/src/main/resources/data/scorchful/loot_table/chests/extra_turtle_scute/shipwreck_treasure.json
@@ -1,0 +1,22 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:turtle_scute",
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 4
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This partially helps with #62. Now that Turtle Scutes are used to make a full set of armour (not just a helmet), it makes sense to make them more easily available to players in the early game. 

- Buried Treasure Chests now contain 2-8 Turtle Scutes 
- Shipwreck 'supply' chests now have a 25% chance of containing 1 Turtle Scute
- Shipwreck 'treasure' chests now contain 1-4 Turtle Scutes