### PR TITLE
Cooling foods tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}"
     modImplementation "org.ladysnake:satin:${satin_version}"
 
+    testmodImplementation "org.mockito:mockito-core:3.+"
 
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}"
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}"

--- a/src/client/java/com/github/thedeathlycow/scorchful/ScorchfulClient.java
+++ b/src/client/java/com/github/thedeathlycow/scorchful/ScorchfulClient.java
@@ -6,7 +6,7 @@ import com.github.thedeathlycow.scorchful.client.ShaderStatusEffectManagers;
 import com.github.thedeathlycow.scorchful.hud.BurningHeartsOverlay;
 import com.github.thedeathlycow.scorchful.hud.MountHealthOverlay;
 import com.github.thedeathlycow.scorchful.hud.SoakingUnderlay;
-import com.github.thedeathlycow.scorchful.item.DrinkItemTooltip;
+import com.github.thedeathlycow.scorchful.item.ItemTooltips;
 import com.github.thedeathlycow.scorchful.item.SModelPredicates;
 import com.github.thedeathlycow.scorchful.network.SoundTemperatureEffectPacketListener;
 import com.github.thedeathlycow.scorchful.registry.SCutouts;
@@ -41,7 +41,8 @@ public class ScorchfulClient implements ClientModInitializer {
         StatusBarOverlayRenderEvents.AFTER_HEALTH_BAR.register(BurningHeartsOverlay.INSTANCE);
         StatusBarOverlayRenderEvents.AFTER_MOUNT_HEALTH_BAR.register(MountHealthOverlay.INSTANCE);
 
-        ItemTooltipCallback.EVENT.register(DrinkItemTooltip::appendTooltip);
+        ItemTooltipCallback.EVENT.register(ItemTooltips::appendDrinkTooltip);
+        ItemTooltipCallback.EVENT.register(ItemTooltips::appendCoolingTooltip);
 
         ClientPlayNetworking.registerGlobalReceiver(
                 TemperatureSoundEventPacket.PACKET_ID,

--- a/src/client/java/com/github/thedeathlycow/scorchful/item/ItemTooltips.java
+++ b/src/client/java/com/github/thedeathlycow/scorchful/item/ItemTooltips.java
@@ -3,42 +3,57 @@ package com.github.thedeathlycow.scorchful.item;
 import com.github.thedeathlycow.scorchful.compat.ScorchfulIntegrations;
 import com.github.thedeathlycow.scorchful.item.component.DrinkLevelComponent;
 import com.github.thedeathlycow.scorchful.registry.SDataComponentTypes;
+import com.github.thedeathlycow.scorchful.registry.tag.SItemTags;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.registry.Registries;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 import java.util.List;
 
-public class DrinkItemTooltip {
+public class ItemTooltips {
 
+    private static final Text COOLING_TOOLTIP = Text.translatable("item.scorchful.tooltip.cooling")
+            .setStyle(Style.EMPTY.withColor(Formatting.AQUA));
 
-    public static void appendTooltip(ItemStack stack, Item.TooltipContext context, TooltipType tooltipType, List<Text> tooltip) {
+    public static void appendDrinkTooltip(ItemStack stack, Item.TooltipContext context, TooltipType tooltipType, List<Text> tooltip) {
         DrinkLevelComponent level = stack.get(SDataComponentTypes.DRINK_LEVEL);
         if (level != null && !ScorchfulIntegrations.isDehydrationLoaded()) {
             if (tooltipType.isAdvanced()) {
-                addTooltipBeforeAdvanced(stack, tooltip, level);
+                addTooltipBeforeAdvanced(stack, tooltip, level.getTooltipText());
             } else {
                 tooltip.add(level.getTooltipText());
             }
         }
     }
 
-    private static void addTooltipBeforeAdvanced(ItemStack stack, List<Text> tooltip, DrinkLevelComponent level) {
+    public static void appendCoolingTooltip(ItemStack stack, Item.TooltipContext context, TooltipType tooltipType, List<Text> tooltip) {
+        if (stack.isIn(SItemTags.IS_COOLING_FOOD)) {
+            if (tooltipType.isAdvanced()) {
+                addTooltipBeforeAdvanced(stack, tooltip, COOLING_TOOLTIP);
+            } else {
+                tooltip.add(COOLING_TOOLTIP);
+            }
+        }
+    }
+
+    private static void addTooltipBeforeAdvanced(ItemStack stack, List<Text> tooltip, Text tooltipText) {
         Identifier identifier = Registries.ITEM.getId(stack.getItem());
         Text idAsText = Text.literal(identifier.toString());
 
         for (int i = tooltip.size() - 1; i >= 0; i--) {
             if (tooltip.get(i).contains(idAsText)) {
-                tooltip.add(i, level.getTooltipText());
+                tooltip.add(i, tooltipText);
                 return;
             }
         }
     }
 
-    private DrinkItemTooltip() {
+    private ItemTooltips() {
 
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -90,7 +90,10 @@ public class Scorchful implements ModInitializer {
         ScorchfulItemEvents.CONSUME_ITEM.register(DrinkItem::applyWater);
         ScorchfulItemEvents.CONSUME_ITEM.register((stack, player) -> {
             if (stack.isIn(SItemTags.IS_COOLING_FOOD)) {
-
+                player.thermoo$addTemperature(
+                        getConfig().heatingConfig.getTemperatureFromCoolingFood(),
+                        HeatingModes.ACTIVE
+                );
             }
         });
         ArmorMaterialEvents.GET_HEAT_RESISTANCE.register(HeatResistanceHelper::getHeatResistance);
@@ -100,7 +103,7 @@ public class Scorchful implements ModInitializer {
                 (entity, source, baseDamageTaken, damageTaken, blocked) -> {
                     if (!blocked && source.isIn(SDamageTypeTags.FIREBALL)) {
                         entity.thermoo$addTemperature(
-                                Scorchful.getConfig().heatingConfig.getFireballHeat(),
+                                getConfig().heatingConfig.getFireballHeat(),
                                 HeatingModes.ACTIVE
                         );
                     }

--- a/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/Scorchful.java
@@ -5,12 +5,14 @@ import com.github.thedeathlycow.scorchful.block.SandCauldronBehaviours;
 import com.github.thedeathlycow.scorchful.config.ScorchfulConfig;
 import com.github.thedeathlycow.scorchful.event.ScorchfulItemEvents;
 import com.github.thedeathlycow.scorchful.event.ScorchfulLivingEntityEvents;
+import com.github.thedeathlycow.scorchful.item.DrinkItem;
 import com.github.thedeathlycow.scorchful.item.FireChargeThrower;
 import com.github.thedeathlycow.scorchful.item.HeatResistanceHelper;
 import com.github.thedeathlycow.scorchful.item.component.DrinkLevelComponent;
 import com.github.thedeathlycow.scorchful.item.loot.TurtleScuteLootTableModifier;
 import com.github.thedeathlycow.scorchful.registry.*;
 import com.github.thedeathlycow.scorchful.registry.tag.SDamageTypeTags;
+import com.github.thedeathlycow.scorchful.registry.tag.SItemTags;
 import com.github.thedeathlycow.scorchful.server.ThirstCommand;
 import com.github.thedeathlycow.scorchful.server.network.TemperatureSoundEventPacket;
 import com.github.thedeathlycow.scorchful.temperature.AmbientTemperatureController;
@@ -85,6 +87,12 @@ public class Scorchful implements ModInitializer {
         );
         UseItemCallback.EVENT.register(new FireChargeThrower());
         ScorchfulItemEvents.GET_DEFAULT_STACK.register(DrinkLevelComponent::applyToNewStack);
+        ScorchfulItemEvents.CONSUME_ITEM.register(DrinkItem::applyWater);
+        ScorchfulItemEvents.CONSUME_ITEM.register((stack, player) -> {
+            if (stack.isIn(SItemTags.IS_COOLING_FOOD)) {
+
+            }
+        });
         ArmorMaterialEvents.GET_HEAT_RESISTANCE.register(HeatResistanceHelper::getHeatResistance);
 
         // custom scorchful event

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
@@ -47,7 +47,7 @@ public class HeatingConfig implements ConfigData {
 
     int maxHeatFromLavaOceanInNether = 3;
 
-    int temperatureFromCoolingFood = -630;
+    int temperatureFromCoolingFood = -1260;
 
     public boolean doPassiveHeating() {
         return doPassiveHeating;

--- a/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/HeatingConfig.java
@@ -47,6 +47,8 @@ public class HeatingConfig implements ConfigData {
 
     int maxHeatFromLavaOceanInNether = 3;
 
+    int temperatureFromCoolingFood = -630;
+
     public boolean doPassiveHeating() {
         return doPassiveHeating;
     }
@@ -125,5 +127,9 @@ public class HeatingConfig implements ConfigData {
 
     public int getMaxHeatFromLavaOceanInNether() {
         return maxHeatFromLavaOceanInNether;
+    }
+
+    public int getTemperatureFromCoolingFood() {
+        return temperatureFromCoolingFood;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/event/ScorchfulItemEvents.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/event/ScorchfulItemEvents.java
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.component.type.AttributeModifiersComponent;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 public class ScorchfulItemEvents {
 
@@ -17,11 +18,22 @@ public class ScorchfulItemEvents {
             }
     );
 
+    public static final Event<ConsumeItemCallback> CONSUME_ITEM = EventFactory.createArrayBacked(
+            ConsumeItemCallback.class,
+            listeners -> (stack, player) -> {
+                for (ConsumeItemCallback listener : listeners) {
+                    listener.consume(stack, player);
+                }
+            }
+    );
+
     @FunctionalInterface
     public interface CreateStack {
-
         void onCreate(ItemStack stack);
-
     }
 
+    @FunctionalInterface
+    public interface ConsumeItemCallback {
+        void consume(ItemStack stack, ServerPlayerEntity player);
+    }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/DrinkItem.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/DrinkItem.java
@@ -70,7 +70,7 @@ public abstract class DrinkItem extends Item {
     }
 
     /**
-     * Called from mixin. Applies water from drinking to the user.
+     * Called from {@link com.github.thedeathlycow.scorchful.event.ScorchfulItemEvents#CONSUME_ITEM}. Applies water from drinking to the user.
      *
      * @param stack  Stack being consumed
      * @param player Player consuming the drink

--- a/src/main/java/com/github/thedeathlycow/scorchful/mixin/thirst/ConsumeItemCriterionMixin.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/mixin/thirst/ConsumeItemCriterionMixin.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.scorchful.mixin.thirst;
 
+import com.github.thedeathlycow.scorchful.event.ScorchfulItemEvents;
 import com.github.thedeathlycow.scorchful.item.DrinkItem;
 import net.minecraft.advancement.criterion.ConsumeItemCriterion;
 import net.minecraft.item.ItemStack;
@@ -17,7 +18,7 @@ public class ConsumeItemCriterionMixin {
             at = @At("HEAD")
     )
     private void onTriggered(ServerPlayerEntity player, ItemStack stack, CallbackInfo ci) {
-        DrinkItem.applyWater(stack, player);
+        ScorchfulItemEvents.CONSUME_ITEM.invoker().consume(stack, player);
     }
 
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SItemTags.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SItemTags.java
@@ -7,6 +7,7 @@ import net.minecraft.registry.tag.TagKey;
 
 public class SItemTags {
 
+    public static final TagKey<Item> IS_COOLING_FOOD = of("is_cooling_food");
     public static final TagKey<Item> IS_REFRESHING = of("is_refreshing");
 
     public static final TagKey<Item> IS_SUSTAINING = of("is_sustaining");

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -122,6 +122,7 @@
     "text.autoconfig.scorchful.option.heatingConfig.minLightLevelForHeatInNether": "Minimum light level for heat (in The Nether)",
     "text.autoconfig.scorchful.option.heatingConfig.blocksAboveLavaOceanPerHeatInNether": "Blocks above Lava Ocean per heat increase (in The Nether)",
     "text.autoconfig.scorchful.option.heatingConfig.maxHeatFromLavaOceanInNether": "Maximum heat from Lava Ocean (in The Nether)",
+    "text.autoconfig.scorchful.option.heatingConfig.temperatureFromCoolingFood": "Temperature from cooling food",
     
     "text.autoconfig.scorchful.option.thirstConfig": "Thirst Config",
     "text.autoconfig.scorchful.option.thirstConfig.temperatureFromWetness": "Temperature from Wetness",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -26,6 +26,7 @@
     "item.minecraft.lingering_potion.effect.scorchful.paranoia": "Lingering Potion of Paranoia",
     "item.minecraft.tipped_arrow.effect.scorchful.paranoia": "Arrow of Paranoia",
     
+    "tag.item.scorchful.is_cooling_food": "Cooling food",
     "tag.item.scorchful.is_hydrating": "Hydrating Food and Drink",
     "tag.item.scorchful.is_parching": "Parching Food and Drink",
     "tag.item.scorchful.is_refreshing": "Refreshing Food and Drink",

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -16,6 +16,7 @@
     "item.scorchful.turtle_leggings": "Turtle Knee Pads",
     "item.scorchful.turtle_boots": "Turtle Flippers",
     
+    "item.scorchful.tooltip.cooling": "Cooling ❄",
     "item.scorchful.tooltip.refreshing": "Refreshing \uD83C\uDF0A",
     "item.scorchful.tooltip.sustaining": "Sustaining \uD83C\uDF0A\uD83C\uDF0A",
     "item.scorchful.tooltip.hydrating": "Hydrating \uD83C\uDF0A\uD83C\uDF0A\uD83C\uDF0A",

--- a/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
+++ b/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
@@ -1,0 +1,37 @@
+{
+    "replace": false,
+    "values": [
+        {
+            "required": false,
+            "id": "beachparty:sweetberry_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:coconut_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:chocolate_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_coconut"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_melon"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_cactus"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_sweetberries"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_chocolate"
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
+++ b/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
@@ -32,6 +32,18 @@
         {
             "required": false,
             "id": "beachparty:icecream_chocolate"
+        },
+        {
+            "required": false,
+            "id": "#c:icicles"
+        },
+        {
+            "required": false,
+            "id": "immersive_weathering:ice_sickle"
+        },
+        {
+            "required": false,
+            "id": "immersive_weathering:icicle"
         }
     ]
 }

--- a/src/main/resources/data/thermoo/tags/entity_type/heat_immune.json
+++ b/src/main/resources/data/thermoo/tags/entity_type/heat_immune.json
@@ -3,7 +3,7 @@
     "values": [
         "minecraft:husk",
         {
-            "replace": false,
+            "required": false,
             "id": "#c:bosses"
         },
         "minecraft:camel",

--- a/src/testmod/java/com/github/thedeathlycow/scorchful/testmod/common/item/CoolingFoodTest.java
+++ b/src/testmod/java/com/github/thedeathlycow/scorchful/testmod/common/item/CoolingFoodTest.java
@@ -1,0 +1,59 @@
+package com.github.thedeathlycow.scorchful.testmod.common.item;
+
+import com.github.thedeathlycow.scorchful.registry.tag.SItemTags;
+import com.github.thedeathlycow.thermoo.api.temperature.TemperatureAware;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.FoodComponent;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.world.GameMode;
+
+
+@SuppressWarnings("unused")
+public class CoolingFoodTest {
+
+    private static final String TEMPERATURE_PROPERTY = "Temperature";
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void consume_cooling_steak_applies_cooling(TestContext context) {
+        final int originalTemperature = 6300;
+        final Item testItem = Items.COOKED_BEEF;
+
+        PlayerEntity mockPlayer = context.createMockPlayer(GameMode.SURVIVAL);
+        mockPlayer.thermoo$setTemperature(originalTemperature);
+        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+
+        ItemStack steak = testItem.getDefaultStack();
+        steak.set(DataComponentTypes.FOOD, new FoodComponent.Builder().alwaysEdible().build());
+        context.assertTrue(steak.isIn(SItemTags.IS_COOLING_FOOD), "Steak SHOULD be cooling food");
+
+        mockPlayer.tryEatFood(context.getWorld(), steak);
+
+        context.testEntity(mockPlayer, p -> p.thermoo$getTemperature() < originalTemperature, "Cooling food reduced temperature");
+        context.complete();
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void consume_not_cooling_pork_does_not_apply_cooling(TestContext context) {
+        final int originalTemperature = 6300;
+        final Item testItem = Items.PORKCHOP;
+
+        PlayerEntity mockPlayer = context.createMockPlayer(GameMode.SURVIVAL);
+        mockPlayer.thermoo$setTemperature(originalTemperature);
+        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+
+        ItemStack porkchop = testItem.getDefaultStack();
+        porkchop.set(DataComponentTypes.FOOD, new FoodComponent.Builder().alwaysEdible().build());
+        context.assertFalse(porkchop.isIn(SItemTags.IS_COOLING_FOOD), "Porkchop should NOT be cooling food");
+
+        mockPlayer.tryEatFood(context.getWorld(), porkchop);
+
+        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+        context.complete();
+    }
+}

--- a/src/testmod/java/com/github/thedeathlycow/scorchful/testmod/common/item/CoolingFoodTest.java
+++ b/src/testmod/java/com/github/thedeathlycow/scorchful/testmod/common/item/CoolingFoodTest.java
@@ -1,17 +1,25 @@
 package com.github.thedeathlycow.scorchful.testmod.common.item;
 
+import com.github.thedeathlycow.scorchful.event.ScorchfulItemEvents;
 import com.github.thedeathlycow.scorchful.registry.tag.SItemTags;
+import com.github.thedeathlycow.thermoo.api.temperature.HeatingModes;
 import com.github.thedeathlycow.thermoo.api.temperature.TemperatureAware;
 import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.advancement.criterion.Criteria;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.FoodComponent;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.component.type.FoodComponents;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.test.GameTest;
 import net.minecraft.test.TestContext;
-import net.minecraft.world.GameMode;
+import net.minecraft.text.Text;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 
 @SuppressWarnings("unused")
@@ -24,17 +32,18 @@ public class CoolingFoodTest {
         final int originalTemperature = 6300;
         final Item testItem = Items.COOKED_BEEF;
 
-        PlayerEntity mockPlayer = context.createMockPlayer(GameMode.SURVIVAL);
-        mockPlayer.thermoo$setTemperature(originalTemperature);
-        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+        ServerPlayerEntity mockPlayer = createMockPlayer();
+        ItemStack steak = createFoodStack(testItem);
 
-        ItemStack steak = testItem.getDefaultStack();
-        steak.set(DataComponentTypes.FOOD, new FoodComponent.Builder().alwaysEdible().build());
         context.assertTrue(steak.isIn(SItemTags.IS_COOLING_FOOD), "Steak SHOULD be cooling food");
 
-        mockPlayer.tryEatFood(context.getWorld(), steak);
+        ScorchfulItemEvents.CONSUME_ITEM.invoker().consume(steak, mockPlayer);
 
-        context.testEntity(mockPlayer, p -> p.thermoo$getTemperature() < originalTemperature, "Cooling food reduced temperature");
+        Mockito.verify(mockPlayer, Mockito.atLeastOnce())
+                .thermoo$addTemperature(
+                        ArgumentMatchers.anyInt(),
+                        ArgumentMatchers.any(HeatingModes.class)
+                );
         context.complete();
     }
 
@@ -43,17 +52,43 @@ public class CoolingFoodTest {
         final int originalTemperature = 6300;
         final Item testItem = Items.PORKCHOP;
 
-        PlayerEntity mockPlayer = context.createMockPlayer(GameMode.SURVIVAL);
-        mockPlayer.thermoo$setTemperature(originalTemperature);
-        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+        ServerPlayerEntity mockPlayer = createMockPlayer();
+        ItemStack porkchop = createFoodStack(testItem);
 
-        ItemStack porkchop = testItem.getDefaultStack();
-        porkchop.set(DataComponentTypes.FOOD, new FoodComponent.Builder().alwaysEdible().build());
         context.assertFalse(porkchop.isIn(SItemTags.IS_COOLING_FOOD), "Porkchop should NOT be cooling food");
 
-        mockPlayer.tryEatFood(context.getWorld(), porkchop);
+        ScorchfulItemEvents.CONSUME_ITEM.invoker().consume(porkchop, mockPlayer);
 
-        context.testEntityProperty(mockPlayer, TemperatureAware::thermoo$getTemperature, TEMPERATURE_PROPERTY, 6300);
+        Mockito.verify(mockPlayer, Mockito.never())
+                .thermoo$addTemperature(
+                        ArgumentMatchers.anyInt(),
+                        ArgumentMatchers.any(HeatingModes.class)
+                );
         context.complete();
+    }
+
+    @NotNull
+    private static ItemStack createFoodStack(Item testItem) {
+        ItemStack stack = testItem.getDefaultStack();
+        stack.set(
+                DataComponentTypes.FOOD,
+                new FoodComponent.Builder()
+                        .nutrition(1)
+                        .saturationModifier(1)
+                        .alwaysEdible()
+                        .build()
+        );
+        return stack;
+    }
+
+    private static ServerPlayerEntity createMockPlayer() {
+        ServerPlayerEntity mockPlayer = Mockito.mock(ServerPlayerEntity.class);
+        Mockito.doNothing()
+                .when(mockPlayer)
+                .thermoo$addTemperature(
+                        ArgumentMatchers.intThat(temp -> temp < 0),
+                        ArgumentMatchers.any(HeatingModes.class)
+                );
+        return mockPlayer;
     }
 }

--- a/src/testmod/resources/data/scorchful/tags/item/is_cooling_food.json
+++ b/src/testmod/resources/data/scorchful/tags/item/is_cooling_food.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:cooked_beef"
+    ]
+}

--- a/src/testmod/resources/fabric.mod.json
+++ b/src/testmod/resources/fabric.mod.json
@@ -9,6 +9,7 @@
         "fabric-gametest": [
             "com.github.thedeathlycow.scorchful.testmod.common.cauldron.CauldronInteractionTests",
             "com.github.thedeathlycow.scorchful.testmod.common.cauldron.SandCauldronTests",
+            "com.github.thedeathlycow.scorchful.testmod.common.item.CoolingFoodTest",
             "com.github.thedeathlycow.scorchful.testmod.common.netherlily.CrimsonLilyTests",
             "com.github.thedeathlycow.scorchful.testmod.common.netherlily.WarpedLilyTests"
         ]


### PR DESCRIPTION
Adds a tag that allows for mod packs to define food items that are cooling. This is different from drinks, as they apply cooling directly. By default this only contains the ice creams from lets do beach party. 