### PR TITLE
Apply impaling damage to wet entities

### DIFF
--- a/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/config/CombatConfig.java
@@ -29,6 +29,9 @@ public class CombatConfig implements ConfigData {
 
     double fearDetectionRangeMultiplier = 2.0;
 
+    @ConfigEntry.Gui.RequiresRestart
+    float impalingDamagePerLevel = 2.5f;
+
     public FireChargeThrower.FireballFactory getFireBallThrownType() {
         return fireBallThrownType;
     }
@@ -57,9 +60,14 @@ public class CombatConfig implements ConfigData {
         return fearDetectionRangeMultiplier;
     }
 
+    public float getImpalingDamagePerLevel() {
+        return impalingDamagePerLevel;
+    }
+
     @Override
     public void validatePostLoad() throws ValidationException {
         ConfigData.super.validatePostLoad();
         this.fearDetectionRangeMultiplier = MathHelper.clamp(fearDetectionRangeMultiplier, 0, 128);
+        this.impalingDamagePerLevel = Math.max(0f, impalingDamagePerLevel);
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/enchantment/EnchantmentModifiers.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/enchantment/EnchantmentModifiers.java
@@ -1,8 +1,55 @@
 package com.github.thedeathlycow.scorchful.item.enchantment;
 
+import com.github.thedeathlycow.thermoo.api.predicate.SoakedLootCondition;
+import net.fabricmc.fabric.api.item.v1.EnchantmentEvents;
+import net.fabricmc.fabric.api.item.v1.EnchantmentSource;
+import net.minecraft.component.EnchantmentEffectComponentTypes;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentLevelBasedValue;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.enchantment.effect.value.AddEnchantmentEffect;
+import net.minecraft.loot.condition.AllOfLootCondition;
+import net.minecraft.loot.condition.EntityPropertiesLootCondition;
+import net.minecraft.loot.condition.InvertedLootCondition;
+import net.minecraft.loot.condition.LootCondition;
+import net.minecraft.loot.context.LootContext;
+import net.minecraft.predicate.NumberRange;
+import net.minecraft.predicate.entity.EntityPredicate;
+import net.minecraft.predicate.entity.EntityTypePredicate;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.tag.EntityTypeTags;
+
 public class EnchantmentModifiers {
 
     public static void initialize() {
+        EnchantmentEvents.MODIFY.register(EnchantmentModifiers::modifyImpaling);
+    }
+
+    private static void modifyImpaling(RegistryKey<Enchantment> key, Enchantment.Builder builder, EnchantmentSource source) {
+        if (!source.isBuiltin() || key != Enchantments.IMPALING) {
+            return;
+        }
+
+        builder.addEffect(
+                EnchantmentEffectComponentTypes.DAMAGE,
+                new AddEnchantmentEffect(EnchantmentLevelBasedValue.linear(2.5f)),
+                AllOfLootCondition.builder(
+                        () -> new SoakedLootCondition(
+                                NumberRange.IntRange.atLeast(1),
+                                NumberRange.DoubleRange.ANY
+                        ),
+                        InvertedLootCondition.builder(
+                                EntityPropertiesLootCondition.builder(
+                                        LootContext.EntityTarget.THIS,
+                                        EntityPredicate.Builder.create()
+                                                .type(EntityTypePredicate.create(EntityTypeTags.SENSITIVE_TO_IMPALING))
+                                )
+                        )
+                )
+        );
+    }
+
+    private EnchantmentModifiers() {
 
     }
 

--- a/src/main/java/com/github/thedeathlycow/scorchful/item/enchantment/EnchantmentModifiers.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/item/enchantment/EnchantmentModifiers.java
@@ -1,5 +1,7 @@
 package com.github.thedeathlycow.scorchful.item.enchantment;
 
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.config.CombatConfig;
 import com.github.thedeathlycow.thermoo.api.predicate.SoakedLootCondition;
 import net.fabricmc.fabric.api.item.v1.EnchantmentEvents;
 import net.fabricmc.fabric.api.item.v1.EnchantmentSource;
@@ -30,9 +32,10 @@ public class EnchantmentModifiers {
             return;
         }
 
+        CombatConfig config = Scorchful.getConfig().combatConfig;
         builder.addEffect(
                 EnchantmentEffectComponentTypes.DAMAGE,
-                new AddEnchantmentEffect(EnchantmentLevelBasedValue.linear(2.5f)),
+                new AddEnchantmentEffect(EnchantmentLevelBasedValue.linear(config.getImpalingDamagePerLevel())),
                 AllOfLootCondition.builder(
                         () -> new SoakedLootCondition(
                                 NumberRange.IntRange.atLeast(1),

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -147,6 +147,7 @@
     "text.autoconfig.scorchful.option.combatConfig.protectiveArmorHeatResistance": "Thermally protective armor piece heat resistance",
     "text.autoconfig.scorchful.option.combatConfig.veryProtectiveArmorHeatResistance": "Very thermally protective armor piece heat resistance",
     "text.autoconfig.scorchful.option.combatConfig.fearDetectionRangeMultiplier": "Fear detection range multiplier",
+    "text.autoconfig.scorchful.option.combatConfig.impalingDamagePerLevel": "Impaling damage per level",
     
     "text.autoconfig.scorchful.option.weatherConfig": "Weather Config",
     "text.autoconfig.scorchful.option.weatherConfig.doSandPileAccumulation": "Do Sand Pile accumulation",

--- a/src/main/resources/data/minecraft/tags/entity_type/sensitive_to_impaling.json
+++ b/src/main/resources/data/minecraft/tags/entity_type/sensitive_to_impaling.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:drowned"
+    ]
+}


### PR DESCRIPTION
Resolves #32 

Applies impaling damage to wet entities based on the soaked loot condition using the new enchantment modify event in FAPI. 

Also makes Drowned always sensitive to impaling, as they should be. 