### PR TITLE
Fix snowy sand layers

### DIFF
--- a/src/main/resources/assets/scorchful/models/block/layered/height10.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height10.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                10,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        6,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        6,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        6,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        6,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height12.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height12.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                12,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        4,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        4,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        4,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        4,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height14.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height14.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                14,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        2,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        2,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        2,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        2,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height2.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height2.json
@@ -1,0 +1,82 @@
+{
+    "parent": "minecraft:block/thin_block",
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                2,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        14,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        14,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        14,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        14,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height4.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height4.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                4,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        12,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        12,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        12,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        12,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height6.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height6.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                6,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        10,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        10,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        10,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        10,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/layered/height8.json
+++ b/src/main/resources/assets/scorchful/models/block/layered/height8.json
@@ -1,0 +1,81 @@
+{
+    "textures": {
+        "particle": "minecraft:block/snow",
+        "texture": "minecraft:block/snow"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                8,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "cullface": "down"
+                },
+                "up": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ]
+                },
+                "north": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        8,
+                        16,
+                        16
+                    ],
+                    "cullface": "north"
+                },
+                "south": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        8,
+                        16,
+                        16
+                    ],
+                    "cullface": "south"
+                },
+                "west": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        8,
+                        16,
+                        16
+                    ],
+                    "cullface": "west"
+                },
+                "east": {
+                    "texture": "#texture",
+                    "uv": [
+                        0,
+                        8,
+                        16,
+                        16
+                    ],
+                    "cullface": "east"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height10.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height10.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height10",
+    "parent": "scorchful:block/layered/height10",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height12.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height12.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height12",
+    "parent": "scorchful:block/layered/height12",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height14.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height14.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height14",
+    "parent": "scorchful:block/layered/height14",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height2.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height2.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height2",
+    "parent": "scorchful:block/layered/height2",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height4.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height4.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height4",
+    "parent": "scorchful:block/layered/height4",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height6.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height6.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height6",
+    "parent": "scorchful:block/layered/height6",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/red_sand_pile/height8.json
+++ b/src/main/resources/assets/scorchful/models/block/red_sand_pile/height8.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height8",
+    "parent": "scorchful:block/layered/height8",
     "textures": {
         "particle": "minecraft:block/red_sand",
         "texture": "minecraft:block/red_sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height10.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height10.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height10",
+    "parent": "scorchful:block/layered/height10",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height12.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height12.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height12",
+    "parent": "scorchful:block/layered/height12",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height14.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height14.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height14",
+    "parent": "scorchful:block/layered/height14",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height2.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height2.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height2",
+    "parent": "scorchful:block/layered/height2",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height4.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height4.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height4",
+    "parent": "scorchful:block/layered/height4",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height6.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height6.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height6",
+    "parent": "scorchful:block/layered/height6",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"

--- a/src/main/resources/assets/scorchful/models/block/sand_pile/height8.json
+++ b/src/main/resources/assets/scorchful/models/block/sand_pile/height8.json
@@ -1,5 +1,5 @@
 {
-    "parent": "minecraft:block/snow_height8",
+    "parent": "scorchful:block/layered/height8",
     "textures": {
         "particle": "minecraft:block/sand",
         "texture": "minecraft:block/sand"


### PR DESCRIPTION
Fixes #84 

Replaces the parent model of sand pile blocks with a copy of the snow layer models, instead of the snow model itself. This should fix mods/resource packs that apply a snow texture to the sides of blocks below from doing that with sand piles. 