### PR TITLE
Make Beaches only hot in Summer

### DIFF
--- a/src/main/resources/data/scorchful/tags/worldgen/biome/temperature/spring/warm.json
+++ b/src/main/resources/data/scorchful/tags/worldgen/biome/temperature/spring/warm.json
@@ -6,7 +6,6 @@
             "id": "#scorchful:warm_biomes"
         },
         "#c:is_hot/overworld",
-        "minecraft:beach",
         "minecraft:warm_ocean",
         "minecraft:mangrove_swamp",
         "#scorchful:temperature/spring/scorching"

--- a/src/main/resources/data/scorchful/tags/worldgen/biome/temperature/summer/warm.json
+++ b/src/main/resources/data/scorchful/tags/worldgen/biome/temperature/summer/warm.json
@@ -2,6 +2,7 @@
     "replace": false,
     "values": [
         "#c:is_temperate",
+        "minecraft:beach",
         "#scorchful:temperature/summer/scorching"
     ]
 }


### PR DESCRIPTION
Beaches are now only hot in the Summer. Beaches often generate near temperate biomes like Forests and Plains, and the transition to them suddenly being hot when other nearby biomes are not is jarring. 