### PR TITLE
Use Thermoo conventional cooling food tag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ mod_menu_version=11.0.1
 cloth_config_version=15.0.127
 
 # Thermoo
-thermoo_version=4.2
+thermoo_version=4.2.3
 
 # Ladysnake Mods
 cca_version=6.1.0

--- a/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
+++ b/src/main/resources/data/scorchful/tags/item/is_cooling_food.json
@@ -1,49 +1,6 @@
 {
     "replace": false,
     "values": [
-        {
-            "required": false,
-            "id": "beachparty:sweetberry_icecream"
-        },
-        {
-            "required": false,
-            "id": "beachparty:coconut_icecream"
-        },
-        {
-            "required": false,
-            "id": "beachparty:chocolate_icecream"
-        },
-        {
-            "required": false,
-            "id": "beachparty:icecream_coconut"
-        },
-        {
-            "required": false,
-            "id": "beachparty:icecream_melon"
-        },
-        {
-            "required": false,
-            "id": "beachparty:icecream_cactus"
-        },
-        {
-            "required": false,
-            "id": "beachparty:icecream_sweetberries"
-        },
-        {
-            "required": false,
-            "id": "beachparty:icecream_chocolate"
-        },
-        {
-            "required": false,
-            "id": "#c:icicles"
-        },
-        {
-            "required": false,
-            "id": "immersive_weathering:ice_sickle"
-        },
-        {
-            "required": false,
-            "id": "immersive_weathering:icicle"
-        }
+        "#thermoo:consumable/cooling"
     ]
 }

--- a/src/main/resources/data/thermoo/tags/item/consumable/cooling.json
+++ b/src/main/resources/data/thermoo/tags/item/consumable/cooling.json
@@ -1,0 +1,49 @@
+{
+    "replace": false,
+    "values": [
+        {
+            "required": false,
+            "id": "beachparty:sweetberry_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:coconut_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:chocolate_icecream"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_coconut"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_melon"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_cactus"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_sweetberries"
+        },
+        {
+            "required": false,
+            "id": "beachparty:icecream_chocolate"
+        },
+        {
+            "required": false,
+            "id": "#c:icicles"
+        },
+        {
+            "required": false,
+            "id": "immersive_weathering:ice_sickle"
+        },
+        {
+            "required": false,
+            "id": "immersive_weathering:icicle"
+        }
+    ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,7 @@
 		"minecraft": "1.21.1",
 		"java": ">=21",
 		"fabric-api": ">=0.105.0",
-		"thermoo": ">=4.2"
+		"thermoo": ">=4.2.3"
 	},
 	"suggests": {
 		"frostiful": "*",


### PR DESCRIPTION
Switches to using the Thermoo conventional tags for cooling foods. Currently this just moves the items to that conventional tag, and then includes it in the old tag, but maybe the old tag can just be removed?