### PR TITLE
Nature's Spirit Pink Sand Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ dependencies {
 
     modCompileOnly "dev.emi:trinkets:${project.trinkets_version}"
     modCompileOnly("maven.modrinth:dehydration:${project.dehydration_version}") { transitive = false }
+    modCompileOnly("maven.modrinth:natures-spirit:${project.natures_spirit_version}")
 
     afterEvaluate {
         subprojects.each {

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,7 @@ satin_version=2.0.0
 
 # Integrations
 trinkets_version=3.8.1
+natures_spirit_version=TRMapjpU
 
 # Thirst mods
 dehydration_version=1.3.6+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ mod_menu_version=11.0.1
 cloth_config_version=15.0.127
 
 # Thermoo
-thermoo_version=4.5
+thermoo_version=4.6.0
 
 # Ladysnake Mods
 cca_version=6.1.0

--- a/src/main/java/com/github/thedeathlycow/scorchful/block/SandCauldronBehaviours.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/block/SandCauldronBehaviours.java
@@ -157,7 +157,7 @@ public class SandCauldronBehaviours {
         return ItemActionResult.success(world.isClient);
     }
 
-    private static CauldronBehavior fillWithSand(BlockState filledState) {
+    public static CauldronBehavior fillWithSand(BlockState filledState) {
         return (state, world, pos, player, hand, stack) -> {
             return fillCauldronWithBlock(
                     world,

--- a/src/main/java/com/github/thedeathlycow/scorchful/block/SandCauldronBlock.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/block/SandCauldronBlock.java
@@ -73,10 +73,11 @@ public class SandCauldronBlock extends AbstractCauldronBlock {
     }
 
     public static boolean canFillWithSand(World world, Sandstorms.SandstormType sandstormType) {
-        return switch (sandstormType) {
-            case RED, REGULAR -> world.getRandom().nextFloat() < FILL_WITH_SAND_CHANCE;
-            default -> false;
-        };
+        if (sandstormType != Sandstorms.SandstormType.NONE) {
+            return world.getRandom().nextFloat() < FILL_WITH_SAND_CHANCE;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
@@ -19,7 +19,6 @@ import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
-import net.minecraft.item.Items;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.sound.SoundEvents;
@@ -58,8 +57,8 @@ public class NaturesSpiritPatch implements DependentModInitializer {
                 settings -> new BlockItem(pinkSandPileBlock, settings)
         );
 
-        SandAccumulation.SAND_PILES.get().put(Sandstorms.SandstormType.PINK, pinkSandPileBlock);
-        SandAccumulation.SAND_CAULDRONS.get().put(Sandstorms.SandstormType.PINK, pinkSandCauldronBlock);
+        SandAccumulation.SAND_PILES.put(Sandstorms.SandstormType.PINK, pinkSandPileBlock);
+        SandAccumulation.SAND_CAULDRONS.put(Sandstorms.SandstormType.PINK, pinkSandCauldronBlock);
 
         RegistryKey<ItemGroup> group = RegistryKey.of(RegistryKeys.ITEM_GROUP, Scorchful.id("main"));
         ItemGroupEvents.modifyEntriesEvent(group).register(entries -> {

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
@@ -1,0 +1,34 @@
+package com.github.thedeathlycow.scorchful.compat;
+
+import com.github.thedeathlycow.scorchful.block.SandPileBlock;
+import com.github.thedeathlycow.scorchful.registry.SBlocks;
+import com.github.thedeathlycow.thermoo.impl.compat.init.DependentModInitializer;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.SnowBlock;
+import net.minecraft.block.piston.PistonBehavior;
+
+public class NaturesSpiritPatch implements DependentModInitializer {
+
+    @Override
+    public void onInitialize() {
+        Block pinkSandPile = SBlocks.register(
+                "pink_sand_pile",
+                settings -> new SandPileBlock(
+                        0xDBD3A0,
+                        settings
+                                .replaceable()
+                                .notSolid()
+                                .blockVision((state, world, pos) -> state.get(SnowBlock.LAYERS) >= SandPileBlock.MAX_LAYERS)
+                                .pistonBehavior(PistonBehavior.DESTROY)
+                ),
+                AbstractBlock.Settings.copy(Blocks.SAND)
+        );
+    }
+
+    @Override
+    public String[] getRequiredModIds() {
+        return new String[] { ScorchfulIntegrations.NATURES_SPIRIT_ID };
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
@@ -1,17 +1,28 @@
 package com.github.thedeathlycow.scorchful.compat;
 
+import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.block.SandCauldronBehaviours;
+import com.github.thedeathlycow.scorchful.block.SandCauldronBlock;
 import com.github.thedeathlycow.scorchful.block.SandPileBlock;
 import com.github.thedeathlycow.scorchful.registry.SBlocks;
 import com.github.thedeathlycow.scorchful.registry.SItems;
 import com.github.thedeathlycow.scorchful.server.SandAccumulation;
 import com.github.thedeathlycow.scorchful.server.Sandstorms;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentModInitializer;
-import net.minecraft.block.AbstractBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.SnowBlock;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.hibiscus.naturespirit.registration.NSMiscBlocks;
+import net.minecraft.block.*;
+import net.minecraft.block.cauldron.CauldronBehavior;
+import net.minecraft.block.enums.NoteBlockInstrument;
 import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.sound.SoundEvents;
 
 public class NaturesSpiritPatch implements DependentModInitializer {
     @Override
@@ -21,6 +32,9 @@ public class NaturesSpiritPatch implements DependentModInitializer {
                 settings -> new SandPileBlock(
                         0xDAAF88,
                         settings
+                                .mapColor(MapColor.RAW_IRON_PINK)
+                                .instrument(NoteBlockInstrument.SNARE)
+                                .strength(0.5f)
                                 .replaceable()
                                 .notSolid()
                                 .blockVision((state, world, pos) -> state.get(SnowBlock.LAYERS) >= SandPileBlock.MAX_LAYERS)
@@ -29,16 +43,62 @@ public class NaturesSpiritPatch implements DependentModInitializer {
                 AbstractBlock.Settings.copy(Blocks.SAND)
         );
 
-        SItems.register(
+        Block pinkSandCauldronBlock = SBlocks.register(
+                "natures_spirit/pink_sand_cauldron",
+                settings -> new SandCauldronBlock(
+                        Sandstorms.SandstormType.PINK,
+                        getPinkSandCauldronBehavior(),
+                        settings
+                ),
+                AbstractBlock.Settings.copy(Blocks.CAULDRON)
+        );
+
+        Item pinkSandPileItem = SItems.register(
                 "natures_spirit/pink_sand_pile",
                 settings -> new BlockItem(pinkSandPileBlock, settings)
         );
 
-        SandAccumulation.SANDSTORM_BLOCK_TYPES.get().put(Sandstorms.SandstormType.PINK, pinkSandPileBlock);
+        SandAccumulation.SAND_PILES.get().put(Sandstorms.SandstormType.PINK, pinkSandPileBlock);
+        SandAccumulation.SAND_CAULDRONS.get().put(Sandstorms.SandstormType.PINK, pinkSandCauldronBlock);
+
+        RegistryKey<ItemGroup> group = RegistryKey.of(RegistryKeys.ITEM_GROUP, Scorchful.id("main"));
+        ItemGroupEvents.modifyEntriesEvent(group).register(entries -> {
+            entries.add(pinkSandPileItem.getDefaultStack());
+        });
+
+        CauldronBehavior.EMPTY_CAULDRON_BEHAVIOR.map().put(
+                NSMiscBlocks.PINK_SAND.asItem(),
+                SandCauldronBehaviours.fillWithSand(
+                        pinkSandCauldronBlock.getDefaultState()
+                                .with(SandCauldronBlock.LEVEL, SandCauldronBlock.MAX_LEVEL)
+                )
+        );
     }
 
     @Override
     public String[] getRequiredModIds() {
-        return new String[] { ScorchfulIntegrations.NATURES_SPIRIT_ID };
+        return new String[]{ScorchfulIntegrations.NATURES_SPIRIT_ID};
+    }
+
+    private static CauldronBehavior.CauldronBehaviorMap getPinkSandCauldronBehavior() {
+        CauldronBehavior.CauldronBehaviorMap map = CauldronBehavior.createMap("scorchful_natures_spirit_pink_sand_cauldron");
+
+        if (map.map() instanceof Object2ObjectOpenHashMap<Item, CauldronBehavior> openHashMap) {
+            openHashMap.defaultReturnValue((state, world, pos, player, hand, stack) -> {
+                return SandCauldronBehaviours.emptyBlockFromCauldron(
+                        state,
+                        world,
+                        pos,
+                        player,
+                        stack,
+                        NSMiscBlocks.PINK_SAND.asItem().getDefaultStack(),
+                        SoundEvents.BLOCK_SAND_PLACE
+                );
+            });
+        } else {
+            Scorchful.LOGGER.error("Unable to register default red sand cauldron behaviour");
+        }
+
+        return map;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
@@ -2,21 +2,24 @@ package com.github.thedeathlycow.scorchful.compat;
 
 import com.github.thedeathlycow.scorchful.block.SandPileBlock;
 import com.github.thedeathlycow.scorchful.registry.SBlocks;
+import com.github.thedeathlycow.scorchful.registry.SItems;
+import com.github.thedeathlycow.scorchful.server.SandAccumulation;
+import com.github.thedeathlycow.scorchful.server.Sandstorms;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentModInitializer;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.SnowBlock;
 import net.minecraft.block.piston.PistonBehavior;
+import net.minecraft.item.BlockItem;
 
 public class NaturesSpiritPatch implements DependentModInitializer {
-
     @Override
     public void onInitialize() {
-        Block pinkSandPile = SBlocks.register(
-                "pink_sand_pile",
+        Block pinkSandPileBlock = SBlocks.register(
+                "natures_spirit/pink_sand_pile",
                 settings -> new SandPileBlock(
-                        0xDBD3A0,
+                        0xDAAF88,
                         settings
                                 .replaceable()
                                 .notSolid()
@@ -25,6 +28,13 @@ public class NaturesSpiritPatch implements DependentModInitializer {
                 ),
                 AbstractBlock.Settings.copy(Blocks.SAND)
         );
+
+        SItems.register(
+                "natures_spirit/pink_sand_pile",
+                settings -> new BlockItem(pinkSandPileBlock, settings)
+        );
+
+        SandAccumulation.SANDSTORM_BLOCK_TYPES.get().put(Sandstorms.SandstormType.PINK, pinkSandPileBlock);
     }
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/NaturesSpiritPatch.java
@@ -4,11 +4,14 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.block.SandCauldronBehaviours;
 import com.github.thedeathlycow.scorchful.block.SandCauldronBlock;
 import com.github.thedeathlycow.scorchful.block.SandPileBlock;
+import com.github.thedeathlycow.scorchful.mixin.accessor.PointOfInterestTypeAccessor;
 import com.github.thedeathlycow.scorchful.registry.SBlocks;
 import com.github.thedeathlycow.scorchful.registry.SItems;
+import com.github.thedeathlycow.scorchful.registry.SPointsOfInterest;
 import com.github.thedeathlycow.scorchful.server.SandAccumulation;
 import com.github.thedeathlycow.scorchful.server.Sandstorms;
 import com.github.thedeathlycow.thermoo.impl.compat.init.DependentModInitializer;
+import com.google.common.collect.ImmutableSet;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.hibiscus.naturespirit.registration.NSMiscBlocks;
@@ -19,9 +22,18 @@ import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.world.poi.PointOfInterestType;
+import net.minecraft.world.poi.PointOfInterestTypes;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class NaturesSpiritPatch implements DependentModInitializer {
     @Override
@@ -72,6 +84,21 @@ public class NaturesSpiritPatch implements DependentModInitializer {
                                 .with(SandCauldronBlock.LEVEL, SandCauldronBlock.MAX_LEVEL)
                 )
         );
+
+        RegistryEntry<PointOfInterestType> leatherWorkerPOI = Registries.POINT_OF_INTEREST_TYPE
+                .getEntry(PointOfInterestTypes.LEATHERWORKER)
+                .orElseThrow();
+
+        Set<BlockState> blockStates = new HashSet<>(pinkSandCauldronBlock.getStateManager().getStates());
+
+        ((PointOfInterestTypeAccessor) (Object) leatherWorkerPOI.value()).scorchful$setBlockStates(
+                ImmutableSet.<BlockState>builder()
+                        .addAll(leatherWorkerPOI.value().blockStates())
+                        .addAll(blockStates)
+                        .build()
+        );
+
+        SPointsOfInterest.registerStates(leatherWorkerPOI, blockStates);
     }
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/scorchful/compat/ScorchfulIntegrations.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/compat/ScorchfulIntegrations.java
@@ -10,6 +10,8 @@ public class ScorchfulIntegrations {
 
     public static final String DEHYDRATION_ID = "dehydration";
 
+    public static final String NATURES_SPIRIT_ID = "natures_spirit";
+
     public static boolean isDehydrationLoaded() {
         return isModLoaded(DEHYDRATION_ID);
     }

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SBlocks.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SBlocks.java
@@ -120,11 +120,11 @@ public final class SBlocks {
         NetherLilyBehaviours.initialize();
     }
 
-    private static Block register(String id, Function<AbstractBlock.Settings, Block> blockFactory) {
+    public static Block register(String id, Function<AbstractBlock.Settings, Block> blockFactory) {
         return register(id, blockFactory, AbstractBlock.Settings.create());
     }
 
-    private static Block register(String id, Function<AbstractBlock.Settings, Block> blockFactory, AbstractBlock.Settings settings) {
+    public static Block register(String id, Function<AbstractBlock.Settings, Block> blockFactory, AbstractBlock.Settings settings) {
         Block block = blockFactory.apply(settings);
         return Registry.register(Registries.BLOCK, Scorchful.id(id), block);
     }

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SItemGroups.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SItemGroups.java
@@ -1,17 +1,24 @@
 package com.github.thedeathlycow.scorchful.registry;
 
 import com.github.thedeathlycow.scorchful.Scorchful;
+import com.github.thedeathlycow.scorchful.compat.ScorchfulIntegrations;
 import com.github.thedeathlycow.scorchful.item.WaterSkinItem;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
 
 public class SItemGroups {
+    private static RegistryKey<Item> pinkSandPileKey = null;
+
     public static final ItemGroup SCORCHFUL = Registry.register(
             Registries.ITEM_GROUP,
             Scorchful.id("main"),
@@ -32,11 +39,19 @@ public class SItemGroups {
                         entries.add(SItems.CRIMSON_LILY.getDefaultStack());
                         entries.add(SItems.WARPED_LILY.getDefaultStack());
                         entries.add(SItems.ROOTED_NETHERRACK.getDefaultStack());
-                        entries.add(SItems. ROOTED_CRIMSON_NYLIUM.getDefaultStack());
+                        entries.add(SItems.ROOTED_CRIMSON_NYLIUM.getDefaultStack());
                         entries.add(SItems.ROOTED_WARPED_NYLIUM.getDefaultStack());
 
                         entries.add(SItems.SAND_PILE.getDefaultStack());
                         entries.add(SItems.RED_SAND_PILE.getDefaultStack());
+
+                        if (ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.NATURES_SPIRIT_ID)) {
+                            Item pinkSandItem = context.lookup()
+                                    .getWrapperOrThrow(RegistryKeys.ITEM)
+                                    .getOrThrow(getPinkSandPileKey())
+                                    .value();
+                            entries.add(pinkSandItem);
+                        }
                     }).build()
     );
 
@@ -49,6 +64,17 @@ public class SItemGroups {
         var filledWaterSkin = SItems.WATER_SKIN.getDefaultStack();
         WaterSkinItem.addDrinks(filledWaterSkin, WaterSkinItem.MAX_DRINKS);
         return filledWaterSkin;
+    }
+
+    private static RegistryKey<Item> getPinkSandPileKey() {
+        if (pinkSandPileKey == null) {
+            pinkSandPileKey = RegistryKey.of(
+                    RegistryKeys.ITEM,
+                    Scorchful.id("natures_spirit/pink_sand_pile")
+            );
+        }
+
+        return pinkSandPileKey;
     }
 
     private SItemGroups() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SItemGroups.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SItemGroups.java
@@ -17,8 +17,6 @@ import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Contract;
 
 public class SItemGroups {
-    private static RegistryKey<Item> pinkSandPileKey = null;
-
     public static final ItemGroup SCORCHFUL = Registry.register(
             Registries.ITEM_GROUP,
             Scorchful.id("main"),
@@ -44,14 +42,6 @@ public class SItemGroups {
 
                         entries.add(SItems.SAND_PILE.getDefaultStack());
                         entries.add(SItems.RED_SAND_PILE.getDefaultStack());
-
-                        if (ScorchfulIntegrations.isModLoaded(ScorchfulIntegrations.NATURES_SPIRIT_ID)) {
-                            Item pinkSandItem = context.lookup()
-                                    .getWrapperOrThrow(RegistryKeys.ITEM)
-                                    .getOrThrow(getPinkSandPileKey())
-                                    .value();
-                            entries.add(pinkSandItem);
-                        }
                     }).build()
     );
 
@@ -64,17 +54,6 @@ public class SItemGroups {
         var filledWaterSkin = SItems.WATER_SKIN.getDefaultStack();
         WaterSkinItem.addDrinks(filledWaterSkin, WaterSkinItem.MAX_DRINKS);
         return filledWaterSkin;
-    }
-
-    private static RegistryKey<Item> getPinkSandPileKey() {
-        if (pinkSandPileKey == null) {
-            pinkSandPileKey = RegistryKey.of(
-                    RegistryKeys.ITEM,
-                    Scorchful.id("natures_spirit/pink_sand_pile")
-            );
-        }
-
-        return pinkSandPileKey;
     }
 
     private SItemGroups() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SItems.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SItems.java
@@ -140,11 +140,11 @@ public final class SItems {
         EnchantmentModifiers.initialize();
     }
 
-    private static Item register(String id, Function<Item.Settings, Item> itemFactory) {
+    public static Item register(String id, Function<Item.Settings, Item> itemFactory) {
         return register(id, itemFactory, new Item.Settings());
     }
 
-    private static Item register(String id, Function<Item.Settings, Item> itemFactory, Item.Settings settings) {
+    public static Item register(String id, Function<Item.Settings, Item> itemFactory, Item.Settings settings) {
         Item item = itemFactory.apply(settings);
 
         return Registry.register(Registries.ITEM, Scorchful.id(id), item);

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/SPointsOfInterest.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/SPointsOfInterest.java
@@ -38,7 +38,7 @@ public final class SPointsOfInterest {
         registerStates(leatherWorkerPOI, SPointsOfInterest.SAND_CAULDRONS);
     }
 
-    private static void registerStates(RegistryEntry<PointOfInterestType> poiTypeEntry, Set<BlockState> states) {
+    public static void registerStates(RegistryEntry<PointOfInterestType> poiTypeEntry, Set<BlockState> states) {
         states.forEach(state -> {
             RegistryEntry<PointOfInterestType> existing = PointOfInterestTypesAccessor.scorchful$getStatesToType()
                     .put(state, poiTypeEntry);

--- a/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SBiomeTags.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/registry/tag/SBiomeTags.java
@@ -17,6 +17,7 @@ public class SBiomeTags {
     public static final TagKey<Biome> HAS_REGULAR_SAND_STORMS = SBiomeTags.register("has_regular_sand_storms");
 
     public static final TagKey<Biome> HAS_RED_SAND_STORMS = SBiomeTags.register("has_red_sand_storms");
+    public static final TagKey<Biome> HAS_PINK_SAND_STORMS = SBiomeTags.register("has_pink_sand_storms");
 
     public static final TagKey<Biome> HAS_FEATURE_CRIMSON_LILY_PATCH = SBiomeTags.register("has_feature/crimson_lily_patch");
     public static final TagKey<Biome> HAS_FEATURE_SPARSE_CRIMSON_LILY_PATCH = SBiomeTags.register("has_feature/sparse_crimson_lily_patch");

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
@@ -9,6 +9,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SnowBlock;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.random.Random;
@@ -23,7 +24,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class SandAccumulation {
-    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SAND_PILES = Suppliers.memoize(
+    public static final Map<Sandstorms.SandstormType, Block> SAND_PILES = Util.make(
             () -> {
                 Map<Sandstorms.SandstormType, Block> map = new EnumMap<>(Sandstorms.SandstormType.class);
                 map.put(Sandstorms.SandstormType.REGULAR, SBlocks.SAND_PILE);
@@ -32,7 +33,7 @@ public class SandAccumulation {
             }
     );
 
-    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SAND_CAULDRONS = Suppliers.memoize(
+    public static final Map<Sandstorms.SandstormType, Block> SAND_CAULDRONS = Util.make(
             () -> {
                 Map<Sandstorms.SandstormType, Block> map = new EnumMap<>(Sandstorms.SandstormType.class);
                 map.put(Sandstorms.SandstormType.REGULAR, SBlocks.SAND_CAULDRON);
@@ -60,8 +61,7 @@ public class SandAccumulation {
         }
 
         // sand pile placement
-        Block sandPile = SAND_PILES.get().get(sandstorm);
-
+        Block sandPile = SAND_PILES.get(sandstorm);
         if (sandPile == null) {
             return;
         }
@@ -80,7 +80,7 @@ public class SandAccumulation {
     public static boolean cauldronSandstormTick(BlockState state, World world, BlockPos pos) {
         Sandstorms.SandstormType sandstorm = Sandstorms.getCurrentSandStorm(world, pos.up());
 
-        Block cauldron = SAND_CAULDRONS.get().get(sandstorm);
+        Block cauldron = SAND_CAULDRONS.get(sandstorm);
 
         if (cauldron != null) {
             world.setBlockState(pos, cauldron.getDefaultState());

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
@@ -4,11 +4,14 @@ import com.github.thedeathlycow.scorchful.Scorchful;
 import com.github.thedeathlycow.scorchful.block.SandPileBlock;
 import com.github.thedeathlycow.scorchful.config.WeatherConfig;
 import com.github.thedeathlycow.scorchful.registry.SBlocks;
+import com.google.common.base.Suppliers;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.SnowBlock;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.random.Random;
@@ -17,11 +20,22 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.event.GameEvent;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class SandAccumulation {
-
+    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SANDSTORM_BLOCK_TYPES = Suppliers.memoize(
+            () -> {
+                Map<Sandstorms.SandstormType, Block> map = new EnumMap<>(Sandstorms.SandstormType.class);
+                map.put(Sandstorms.SandstormType.REGULAR, SBlocks.SAND_PILE);
+                map.put(Sandstorms.SandstormType.RED, SBlocks.RED_SAND_PILE);
+                return map;
+            }
+    );
 
     public static void tickChunk(ServerWorld world, WorldChunk chunk, int randomTickSpeed) {
         // choose position
@@ -42,13 +56,14 @@ public class SandAccumulation {
         }
 
         // sand pile placement
-        Block sandPile = null;
-        WeatherConfig config = Scorchful.getConfig().weatherConfig;
-        if (Objects.requireNonNull(sandstorm) == Sandstorms.SandstormType.REGULAR) {
-            sandPile = SBlocks.SAND_PILE;
-        } else if (sandstorm == Sandstorms.SandstormType.RED) {
-            sandPile = SBlocks.RED_SAND_PILE;
+        Block sandPile = SANDSTORM_BLOCK_TYPES.get().get(sandstorm);
+
+        if (sandPile == null) {
+            return;
         }
+
+        WeatherConfig config = Scorchful.getConfig().weatherConfig;
+
         placeSandPile(world, topPos, sandPile, config);
 
         // cauldron tick

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/SandAccumulation.java
@@ -5,13 +5,10 @@ import com.github.thedeathlycow.scorchful.block.SandPileBlock;
 import com.github.thedeathlycow.scorchful.config.WeatherConfig;
 import com.github.thedeathlycow.scorchful.registry.SBlocks;
 import com.google.common.base.Suppliers;
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SnowBlock;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.random.Random;
@@ -20,19 +17,26 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.event.GameEvent;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 public class SandAccumulation {
-    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SANDSTORM_BLOCK_TYPES = Suppliers.memoize(
+    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SAND_PILES = Suppliers.memoize(
             () -> {
                 Map<Sandstorms.SandstormType, Block> map = new EnumMap<>(Sandstorms.SandstormType.class);
                 map.put(Sandstorms.SandstormType.REGULAR, SBlocks.SAND_PILE);
                 map.put(Sandstorms.SandstormType.RED, SBlocks.RED_SAND_PILE);
+                return map;
+            }
+    );
+
+    public static final Supplier<Map<Sandstorms.SandstormType, Block>> SAND_CAULDRONS = Suppliers.memoize(
+            () -> {
+                Map<Sandstorms.SandstormType, Block> map = new EnumMap<>(Sandstorms.SandstormType.class);
+                map.put(Sandstorms.SandstormType.REGULAR, SBlocks.SAND_CAULDRON);
+                map.put(Sandstorms.SandstormType.RED, SBlocks.RED_SAND_CAULDRON);
                 return map;
             }
     );
@@ -56,7 +60,7 @@ public class SandAccumulation {
         }
 
         // sand pile placement
-        Block sandPile = SANDSTORM_BLOCK_TYPES.get().get(sandstorm);
+        Block sandPile = SAND_PILES.get().get(sandstorm);
 
         if (sandPile == null) {
             return;
@@ -76,19 +80,15 @@ public class SandAccumulation {
     public static boolean cauldronSandstormTick(BlockState state, World world, BlockPos pos) {
         Sandstorms.SandstormType sandstorm = Sandstorms.getCurrentSandStorm(world, pos.up());
 
-        return switch (sandstorm) {
-            case REGULAR -> {
-                world.setBlockState(pos, SBlocks.SAND_CAULDRON.getDefaultState());
-                world.emitGameEvent(null, GameEvent.BLOCK_CHANGE, pos);
-                yield true;
-            }
-            case RED -> {
-                world.setBlockState(pos, SBlocks.RED_SAND_CAULDRON.getDefaultState());
-                world.emitGameEvent(null, GameEvent.BLOCK_CHANGE, pos);
-                yield true;
-            }
-            default -> false;
-        };
+        Block cauldron = SAND_CAULDRONS.get().get(sandstorm);
+
+        if (cauldron != null) {
+            world.setBlockState(pos, cauldron.getDefaultState());
+            world.emitGameEvent(null, GameEvent.BLOCK_CHANGE, pos);
+            return true;
+        }
+
+        return false;
     }
 
     private static void placeSandPile(ServerWorld world, BlockPos topPos, Block sandPileBlock, WeatherConfig config) {

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/Sandstorms.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/Sandstorms.java
@@ -15,7 +15,8 @@ public class Sandstorms {
     public enum SandstormType implements StringIdentifiable {
         NONE("no_sandstorm"),
         REGULAR("regular_sandstorm"),
-        RED("red_sandstorm");
+        RED("red_sandstorm"),
+        PINK("pink_sandstorm");
 
         public static final Codec<SandstormType> CODEC = StringIdentifiable.createCodec(SandstormType::values);
 
@@ -55,6 +56,8 @@ public class Sandstorms {
             return SandstormType.REGULAR;
         } else if (hasRedSandStorms(biome)) {
             return SandstormType.RED;
+        } else if (hasPinkSandStorms(biome)) {
+            return SandstormType.RED;
         } else {
             return SandstormType.NONE;
         }
@@ -86,6 +89,10 @@ public class Sandstorms {
 
     public static boolean hasRedSandStorms(RegistryEntry<Biome> biome) {
         return !biome.value().hasPrecipitation() && biome.isIn(SBiomeTags.HAS_RED_SAND_STORMS);
+    }
+
+    public static boolean hasPinkSandStorms(RegistryEntry<Biome> biome) {
+        return !biome.value().hasPrecipitation() && biome.isIn(SBiomeTags.HAS_PINK_SAND_STORMS);
     }
 
     private Sandstorms() {

--- a/src/main/java/com/github/thedeathlycow/scorchful/server/Sandstorms.java
+++ b/src/main/java/com/github/thedeathlycow/scorchful/server/Sandstorms.java
@@ -52,12 +52,12 @@ public class Sandstorms {
             return SandstormType.NONE;
         }
         RegistryEntry<Biome> biome = world.getBiome(pos);
-        if (hasRegularSandStorms(biome)) {
-            return SandstormType.REGULAR;
-        } else if (hasRedSandStorms(biome)) {
+        if (hasRedSandStorms(biome)) {
             return SandstormType.RED;
         } else if (hasPinkSandStorms(biome)) {
-            return SandstormType.RED;
+            return SandstormType.PINK;
+        } else if (hasRegularSandStorms(biome)) {
+            return SandstormType.REGULAR;
         } else {
             return SandstormType.NONE;
         }

--- a/src/main/resources/assets/scorchful/blockstates/natures_spirit/pink_sand_cauldron.json
+++ b/src/main/resources/assets/scorchful/blockstates/natures_spirit/pink_sand_cauldron.json
@@ -1,0 +1,13 @@
+{
+    "variants": {
+        "level=1": {
+            "model": "scorchful:block/natures_spirit/pink_sand_cauldron/level1"
+        },
+        "level=2": {
+            "model": "scorchful:block/natures_spirit/pink_sand_cauldron/level2"
+        },
+        "level=3": {
+            "model": "scorchful:block/natures_spirit/pink_sand_cauldron/full"
+        }
+    }
+}

--- a/src/main/resources/assets/scorchful/blockstates/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/assets/scorchful/blockstates/natures_spirit/pink_sand_pile.json
@@ -1,0 +1,28 @@
+{
+    "variants": {
+        "layers=1": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height2"
+        },
+        "layers=2": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height4"
+        },
+        "layers=3": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height6"
+        },
+        "layers=4": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height8"
+        },
+        "layers=5": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height10"
+        },
+        "layers=6": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height12"
+        },
+        "layers=7": {
+            "model": "scorchful:block/natures_spirit/pink_sand_pile/height14"
+        },
+        "layers=8": {
+            "model": "natures_spirit:block/pink_sand"
+        }
+    }
+}

--- a/src/main/resources/assets/scorchful/lang/en_us.json
+++ b/src/main/resources/assets/scorchful/lang/en_us.json
@@ -55,6 +55,8 @@
     "block.scorchful.red_sand_pile": "Red Sand Pile",
     "block.scorchful.sand_cauldron": "Sand Cauldron",
     "block.scorchful.red_sand_cauldron": "Red Sand Cauldron",
+    "block.scorchful.natures_spirit.pink_sand_pile": "Pink Sand Pile",
+    "block.scorchful.natures_spirit.pink_sand_cauldron": "Pink Sand Cauldron",
     
 
     "enchantment.scorchful.rehydration": "Rehydration",

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/full.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/full.json
@@ -1,0 +1,11 @@
+{
+    "parent": "minecraft:block/template_cauldron_full",
+    "textures": {
+        "bottom": "minecraft:block/cauldron_bottom",
+        "content": "natures_spirit:block/pink_sand",
+        "inside": "minecraft:block/cauldron_inner",
+        "particle": "minecraft:block/cauldron_side",
+        "side": "minecraft:block/cauldron_side",
+        "top": "minecraft:block/cauldron_top"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/level1.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/level1.json
@@ -1,0 +1,11 @@
+{
+    "parent": "minecraft:block/template_cauldron_level1",
+    "textures": {
+        "bottom": "minecraft:block/cauldron_bottom",
+        "content": "natures_spirit:block/pink_sand",
+        "inside": "minecraft:block/cauldron_inner",
+        "particle": "minecraft:block/cauldron_side",
+        "side": "minecraft:block/cauldron_side",
+        "top": "minecraft:block/cauldron_top"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/level2.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_cauldron/level2.json
@@ -1,0 +1,11 @@
+{
+    "parent": "minecraft:block/template_cauldron_level2",
+    "textures": {
+        "bottom": "minecraft:block/cauldron_bottom",
+        "content": "natures_spirit:block/pink_sand",
+        "inside": "minecraft:block/cauldron_inner",
+        "particle": "minecraft:block/cauldron_side",
+        "side": "minecraft:block/cauldron_side",
+        "top": "minecraft:block/cauldron_top"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height10.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height10.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height10",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height12.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height12.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height12",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height14.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height14.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height14",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height2.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height2.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height2",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height4.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height4.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height4",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height6.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height6.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height6",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height8.json
+++ b/src/main/resources/assets/scorchful/models/block/natures_spirit/pink_sand_pile/height8.json
@@ -1,0 +1,7 @@
+{
+    "parent": "scorchful:block/layered/height8",
+    "textures": {
+        "particle": "natures_spirit:block/pink_sand",
+        "texture": "natures_spirit:block/pink_sand"
+    }
+}

--- a/src/main/resources/assets/scorchful/models/item/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/assets/scorchful/models/item/natures_spirit/pink_sand_pile.json
@@ -1,0 +1,3 @@
+{
+    "parent": "scorchful:block/natures_spirit/pink_sand_pile/height2"
+}

--- a/src/main/resources/data/scorchful/advancement/recipes/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/data/scorchful/advancement/recipes/natures_spirit/pink_sand_pile.json
@@ -1,0 +1,42 @@
+{
+    "parent": "minecraft:recipes/root",
+    "criteria": {
+        "has_pink_sand": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "items": [
+                            "natures_spirit:pink_sand"
+                        ]
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "scorchful:natures_spirit/pink_sand_pile"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_recipe",
+            "has_pink_sand"
+        ]
+    ],
+    "rewards": {
+        "recipes": [
+            "scorchful:natures_spirit/pink_sand_pile"
+        ]
+    },
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "natures_spirit"
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/loot_table/blocks/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/data/scorchful/loot_table/blocks/natures_spirit/pink_sand_pile.json
@@ -147,6 +147,10 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "minecraft:sand"
                         }
                     ]
                 }

--- a/src/main/resources/data/scorchful/loot_table/blocks/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/data/scorchful/loot_table/blocks/natures_spirit/pink_sand_pile.json
@@ -1,0 +1,176 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "bonus_rolls": 0,
+            "entries": [
+                {
+                    "type": "minecraft:alternatives",
+                    "children": [
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 1,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "1"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 2,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "2"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 3,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "3"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 4,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "4"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 5,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "5"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 6,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "6"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "scorchful:natures_spirit/pink_sand_pile",
+                            "functions": [
+                                {
+                                    "function": "minecraft:set_count",
+                                    "count": 7,
+                                    "add": false
+                                }
+                            ],
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:block_state_property",
+                                    "block": "scorchful:natures_spirit/pink_sand_pile",
+                                    "properties": {
+                                        "layers": "7"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:match_tool",
+                    "predicate": {
+                        "enchantments": [
+                            {
+                                "enchantment": "minecraft:silk_touch"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "natures_spirit"
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/recipe/natures_spirit/pink_sand_pile.json
+++ b/src/main/resources/data/scorchful/recipe/natures_spirit/pink_sand_pile.json
@@ -1,0 +1,23 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "###"
+    ],
+    "key": {
+        "#": {
+            "item": "natures_spirit:pink_sand"
+        }
+    },
+    "result": {
+        "id": "scorchful:natures_spirit/pink_sand_pile",
+        "count": 6
+    },
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "natures_spirit"
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/scorchful/tags/worldgen/biome/has_pink_sand_storms.json
+++ b/src/main/resources/data/scorchful/tags/worldgen/biome/has_pink_sand_storms.json
@@ -1,14 +1,13 @@
 {
     "replace": false,
     "values": [
-        "#minecraft:is_badlands",
         {
             "required": false,
-            "id": "#c:is_badlands"
+            "id": "natures_spirit:drylands"
         },
         {
             "required": false,
-            "id": "natures_spirit:scorched_dunes"
+            "id": "natures_spirit:wooded_drylands"
         }
     ]
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,6 +33,9 @@
 		],
 		"cardinal-components-entity": [
 			"com.github.thedeathlycow.scorchful.components.ScorchfulComponents"
+		],
+		"thermoo-dependent-mod": [
+			"com.github.thedeathlycow.scorchful.compat.NaturesSpiritPatch"
 		]
 	},
 	"mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -47,7 +47,7 @@
 		"minecraft": "1.21.1",
 		"java": ">=21",
 		"fabric-api": ">=0.115.4",
-		"thermoo": ">=4.5"
+		"thermoo": ">=4.6.0"
 	},
 	"suggests": {
 		"frostiful": "*",


### PR DESCRIPTION
Resolves #118 

Integrates pink sand from Nature's Spirit into Scorchful with Pink Sand Piles and Pink Sand Cauldrons. These will appear in place of the regular sand piles and sand cauldrons in sandstorms in the Drylands biomes. The relevant blocks and items will not be registered if Nature's Spirit is not installed.